### PR TITLE
fix: @click event in clipboard livewire conflict

### DIFF
--- a/resources/views/clipboard.blade.php
+++ b/resources/views/clipboard.blade.php
@@ -7,9 +7,9 @@
         class="clipboard @unless($noStyling ?? false) button-icon @endif {{ $class ?? 'h-10 w-12' }}"
         tooltip-content="{{ ($tooltipContent ?? '') ? $tooltipContent : trans('tooltips.copied') }}"
         @if($copyInput ?? false)
-            @click="copyFromInput('{{ $value }}')"
+            x-on:click="copyFromInput('{{ $value }}')"
         @else
-            @click="copy('{{ $value }}')"
+            x-on:click="copy('{{ $value }}')"
         @endif
     >
         @svg('copy', 'h-4 w-4')


### PR DESCRIPTION
## Summary

There is a strange bug in the table of servers on the user home page, to reproduce you just need to change the list of servers for another server type or another token, in the screenshot above the select tab is "development" if I click on the "production" tab it throws

```
Uncaught (in promise) DOMException: Failed to execute 'setAttribute' on 'Element': '@click' is not a valid attribute name.
    at morphAttrs (https://one-click.test/vendor/livewire/livewire.js?id=c1db26b321e994f87254:13:77001)
```

After spending a lot of time on this all points to be a conflict within livewire and  alpine (related issue https://github.com/livewire/livewire/issues/828)

![Screen Shot 2020-10-29 at 13 28 11](https://user-images.githubusercontent.com/17262776/97623068-0d090200-1a1d-11eb-9409-f202d78ce4e5.png)

After changing @change for `x-on:change` the problem is fixed

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged


