### PR TITLE
feat: rich select component

### DIFF
--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -2,6 +2,7 @@
     'options',
     'initialValue' => null,
     'dispatchEvent' => null,
+    'setValueFromEvent' => null,
     'buttonClass' => 'inline-block w-full px-4 py-3 text-left form-input transition-default dark:bg-theme-secondary-900 dark:border-theme-secondary-800',
     'wrapperClass' => 'w-full',
     'dropdownClass' => 'mt-1',
@@ -11,6 +12,9 @@
 ])
 
 <div
+    @if($setValueFromEvent)
+    {{ '@' . $setValueFromEvent }}.window="choose($event.detail)"
+    @endif
     class="relative {{ $wrapperClass }}"
     x-data="{
         options: {{ json_encode($options) }},
@@ -44,6 +48,10 @@
         value: null,
         text: null,
         choose: function(value, groupName = null) {
+            if (this.value === value) {
+                return;
+            }
+
             this.value = value;
 
             this.text = groupName !==null

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -4,6 +4,7 @@
     'dispatchEvent' => null,
     'buttonClass' => 'inline-block w-full px-4 py-3 text-left form-input transition-default dark:bg-theme-secondary-900 dark:border-theme-secondary-800',
     'wrapperClass' => 'w-full',
+    'dropdownClass' => 'mt-1',
     'iconClass' => 'absolute inset-y-0 right-0 flex items-center justify-center mr-4',
     'placeholder' => '',
     'grouped' => false,
@@ -161,7 +162,7 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="absolute w-full mt-1 min-w-max-content"
+        class="absolute w-full min-w-max-content {{ $dropdownClass }}"
         style="display: none;"
     >
         <div

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -1,0 +1,145 @@
+@props([
+    'options',
+    'initialValue' => null,
+    'dispatchEvent' => null,
+    'buttonClass' => 'inline-block w-full px-4 py-3 text-left form-input transition-default',
+    'wrapperClass' => 'w-full',
+    'placeholder' => '',
+])
+
+<div
+    class="relative {{ $wrapperClass }}"
+    x-data="{
+        options: {{ json_encode($options) }},
+        onInput($dispatch) {
+            @isset($dispatchEvent)
+            $dispatch('{{$dispatchEvent}}', this.value)
+            @endisset
+        },
+        init: function() {
+            this.$nextTick(() => {
+                this.optionsCount = this.$refs.listbox.children.length;
+            });
+        },
+        optionsCount: null,
+        open: false,
+        selected: 1,
+        value: @isset($initialValue) '{{ $initialValue }}' @else null @endif,
+        choose: function(value) {
+            this.value = value;
+            this.open = false;
+
+            const { input } = this.$refs;
+            input.value = value
+
+            const event = new Event('input', {
+                bubbles: true,
+                cancelable: true,
+            });
+
+            input.dispatchEvent(event);
+        },
+        onButtonClick: function() {
+            const { listbox } = this.$refs;
+            const selectedIndex = Object.keys(this.options).indexOf(this.value);
+            this.selected = selectedIndex >= 0 ? selectedIndex : 0;
+            this.open = true;
+            this.$nextTick(() => {
+                listbox.focus();
+                listbox.children[this.selected].scrollIntoView({
+                    block: 'nearest'
+                });
+            })
+        },
+        onOptionSelect: function() {
+            if (null !== this.selected) {
+                this.choose(Object.keys(this.options)[this.selected])
+            }
+            this.open = false;
+            this.$refs.button.focus();
+        },
+        onEscape: function() {
+            this.open = false;
+            this.$refs.button.focus();
+        },
+        onArrowUp: function() {
+            const { listbox } = this.$refs;
+            this.selected = this.selected - 1 < 0 ? this.optionsCount - 1 : this.selected - 1;
+            listbox.children[this.selected].scrollIntoView({
+                block: 'nearest'
+            });
+        },
+        onArrowDown: function() {
+            const { listbox } = this.$refs;
+            this.selected = this.selected + 1 > this.optionsCount - 1 ? 1 : this.selected + 1;
+            listbox.children[this.selected].scrollIntoView({
+                block: 'nearest'
+            });
+        },
+    }"
+    x-init="init()"
+>
+    <input x-ref="input" {{ $attributes }} type="hidden" @input="onInput($dispatch)" />
+
+    <button
+        x-ref="button"
+        @keydown.arrow-up.stop.prevent="onButtonClick()"
+        @keydown.arrow-down.stop.prevent="onButtonClick()"
+        @click="onButtonClick()"
+        type="button"
+        aria-haspopup="listbox"
+        :aria-expanded="open"
+        aria-labelledby="listbox-label"
+        class="relative pr-10 {{ $buttonClass }}"
+    >
+        <span x-show="options[value]" x-text="options[value]" class="block truncate"></span>
+        <span x-show="!options[value]" class="block truncate">@if(isset($placeholder) && $placeholder) {{ $placeholder }} @else &nbsp; @endif</span>
+
+        <span class="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none">
+            <x-icon name="chevron-down" size="xs" />
+        </span>
+    </button>
+
+    <div
+        x-show="open"
+        @click.away="open = false"
+        x-description="Select popover, show/hide based on select state."
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="absolute w-full mt-1 min-w-max-content"
+        style="display: none;"
+    >
+        <ul
+            @keydown.enter.stop.prevent="onOptionSelect()"
+            @keydown.space.stop.prevent="onOptionSelect()"
+            @keydown.escape="onEscape()"
+            @keydown.arrow-up.prevent="onArrowUp()"
+            @keydown.arrow-down.prevent="onArrowDown()"
+            x-ref="listbox"
+            tabindex="-1"
+            role="listbox"
+            aria-labelledby="listbox-label"
+            class="py-3 overflow-auto bg-white rounded-md shadow-xs outline-none dark:bg-theme-secondary-800 dark:text-theme-secondary-200 hover:outline-none max-h-80"
+        >
+            <template x-for="(optionValue, index) in Object.keys(options)" :key="optionValue">
+                <li
+                    x-description="Select option, manage highlight styles based on mouseenter/mouseleave and keyboard navigation."
+                    x-state:on="Highlighted"
+                    x-state:off="Not Highlighted"
+                    :id="`listbox-option-${optionValue}`"
+                    role="option"
+                    @click="choose(optionValue)"
+                    @mouseenter="selected = index"
+                    @mouseleave="selected = null"
+                    :class="{
+                        'dropdown-entry-selected': value === optionValue,
+                        'bg-theme-primary-50': selected === index
+                    }"
+                    class="py-1 cursor-pointer dropdown-entry"
+                    x-text="options[optionValue]"
+                ></li>
+            </template>
+        </ul>
+    </div>
+</div>

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -94,7 +94,7 @@
         class="relative pr-10 {{ $buttonClass }}"
     >
         <span x-show="options[value]" x-text="options[value]" class="block truncate dark:text-theme-secondary-300"></span>
-        <span x-show="!options[value]" class="block truncate dark:text-theme-secondary-700">@if(isset($placeholder) && $placeholder) {{ $placeholder }} @else &nbsp; @endif</span>
+        <span x-show="!options[value]" class="block truncate text-theme-secondary-500 dark:text-theme-secondary-700">@if(isset($placeholder) && $placeholder) {{ $placeholder }} @else &nbsp; @endif</span>
 
         <span
             class="{{ $iconClass }} transition duration-150 transform pointer-events-none"
@@ -143,7 +143,7 @@
                     @mouseleave="selected = null"
                     :class="{
                         'bg-theme-danger-400 text-theme-secondary-200': value === optionValue,
-                        'bg-theme-primary-100 text-theme-primary-600 dark:bg-theme-primary-600 dark:text-theme-secondary-200': selected === index,
+                        'bg-theme-primary-100 text-theme-primary-600 dark:bg-theme-primary-600 dark:text-theme-secondary-200': selected === index && value !== optionValue,
                     }"
                     class="px-8 py-4 font-semibold transition duration-150 ease-in-out cursor-pointer hover:bg-theme-primary-100 hover:text-theme-primary-600 dark:hover:bg-theme-primary-600 dark:hover:text-theme-secondary-200"
                     x-text="options[optionValue]"

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -2,8 +2,9 @@
     'options',
     'initialValue' => null,
     'dispatchEvent' => null,
-    'buttonClass' => 'inline-block w-full px-4 py-3 text-left form-input transition-default',
+    'buttonClass' => 'inline-block w-full px-4 py-3 text-left form-input transition-default dark:bg-theme-secondary-900 dark:border-theme-secondary-800',
     'wrapperClass' => 'w-full',
+    'iconClass' => 'absolute inset-y-0 right-0 flex items-center justify-center mr-4',
     'placeholder' => '',
 ])
 
@@ -92,11 +93,17 @@
         aria-labelledby="listbox-label"
         class="relative pr-10 {{ $buttonClass }}"
     >
-        <span x-show="options[value]" x-text="options[value]" class="block truncate"></span>
-        <span x-show="!options[value]" class="block truncate">@if(isset($placeholder) && $placeholder) {{ $placeholder }} @else &nbsp; @endif</span>
+        <span x-show="options[value]" x-text="options[value]" class="block truncate dark:text-theme-secondary-300"></span>
+        <span x-show="!options[value]" class="block truncate dark:text-theme-secondary-700">@if(isset($placeholder) && $placeholder) {{ $placeholder }} @else &nbsp; @endif</span>
 
-        <span class="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none">
-            <x-icon name="chevron-down" size="xs" />
+        <span
+            class="{{ $iconClass }} transition duration-150 transform pointer-events-none"
+            :class="{ 'rotate-180': open }"
+        >
+            <x-icon
+                name="chevron-down"
+                size="xs"
+            />
         </span>
     </button>
 
@@ -133,10 +140,9 @@
                     @mouseenter="selected = index"
                     @mouseleave="selected = null"
                     :class="{
-                        'dropdown-entry-selected': value === optionValue,
-                        'bg-theme-primary-50': selected === index
+                        'bg-theme-danger-400 text-theme-secondary-200': value === optionValue || selected === index,
                     }"
-                    class="py-1 cursor-pointer dropdown-entry"
+                    class="px-8 py-4 font-semibold transition duration-150 ease-in-out cursor-pointer hover:bg-theme-primary-100 hover:text-theme-primary-600 dark:hover:bg-theme-primary-600 dark:hover:text-theme-secondary-200"
                     x-text="options[optionValue]"
                 ></li>
             </template>

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -110,10 +110,12 @@
     <div
         x-show="open"
         @click.away="open = false"
-        x-description="Select popover, show/hide based on select state."
-        x-transition:leave="transition ease-in duration-100"
-        x-transition:leave-start="opacity-100"
-        x-transition:leave-end="opacity-0"
+        x-transition:enter="transition ease-out duration-100"
+        x-transition:enter-start="transform opacity-0 scale-95"
+        x-transition:enter-end="transform opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-75"
+        x-transition:leave-start="transform opacity-100 scale-100"
+        x-transition:leave-end="transform opacity-0 scale-95"
         class="absolute w-full mt-1 min-w-max-content"
         style="display: none;"
     >
@@ -140,7 +142,8 @@
                     @mouseenter="selected = index"
                     @mouseleave="selected = null"
                     :class="{
-                        'bg-theme-danger-400 text-theme-secondary-200': value === optionValue || selected === index,
+                        'bg-theme-danger-400 text-theme-secondary-200': value === optionValue,
+                        'bg-theme-primary-100 text-theme-primary-600 dark:bg-theme-primary-600 dark:text-theme-secondary-200': selected === index,
                     }"
                     class="px-8 py-4 font-semibold transition duration-150 ease-in-out cursor-pointer hover:bg-theme-primary-100 hover:text-theme-primary-600 dark:hover:bg-theme-primary-600 dark:hover:text-theme-secondary-200"
                     x-text="options[optionValue]"

--- a/src/UserInterfaceServiceProvider.php
+++ b/src/UserInterfaceServiceProvider.php
@@ -118,6 +118,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
         Blade::component('ark::inputs.select', 'ark-select');
         Blade::component('ark::inputs.upload', 'ark-upload');
         Blade::component('ark::inputs.password-toggle', 'ark-password-toggle');
+        Blade::component('ark::inputs.rich-select', 'ark-rich-select');
 
         Blade::component('ark::accordion-group', 'ark-accordion-group');
         Blade::component('ark::accordion', 'ark-accordion');


### PR DESCRIPTION
## Summary

Rich select component based on the style guide:

![image](https://user-images.githubusercontent.com/17262776/98404850-36501080-2063-11eb-9830-0031b51fd568.png)
![image](https://user-images.githubusercontent.com/17262776/98404860-3c45f180-2063-11eb-93e3-cf7554365398.png)
![image](https://user-images.githubusercontent.com/17262776/98404893-4831b380-2063-11eb-9d36-bf8dd22d6508.png)
![image](https://user-images.githubusercontent.com/17262776/98404899-4cf66780-2063-11eb-832e-98124baa6ada.png)

Note: the only place this component is used is on the explorer advanced search (pending PR); there, it has a different button style. The screenshot is for the default styling

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
