### PR TITLE
fix: ensure purgecss does not remove table hover related styles

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -59,6 +59,7 @@
 }
 
 /* Table highlight & hover effect (requires to use `<x-ark-tables.cell` instead of a `td`) */
+/* purgecss ignore */
 .table-container table tbody td.table-cell {
     @apply px-0 py-0.5;
 }
@@ -352,3 +353,4 @@
     > div::before {
     @apply bg-transparent;
 }
+/* purgecss end ignore */

--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -59,7 +59,6 @@
 }
 
 /* Table highlight & hover effect (requires to use `<x-ark-tables.cell` instead of a `td`) */
-/* purgecss ignore */
 .table-container table tbody td.table-cell {
     @apply px-0 py-0.5;
 }
@@ -353,4 +352,3 @@
     > div::before {
     @apply bg-transparent;
 }
-/* purgecss end ignore */

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -156,6 +156,7 @@ module.exports = {
         options: {
             whitelistPatterns: [
                 /horizontal$/,
+                /table-cell/,
                 /alert-/,
                 /swiper-/,
                 /toast-/,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Some of the CSS related to the hover/highlighting  for the table rows is being removed in production builds, this PR prevents that

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
