### PR TITLE
fix: ensure the initial value is added to the hidden input

### DIFF
--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -29,6 +29,8 @@
                 this.text = '{{ $grouped
                     ? collect($options)->flatMap(fn ($value) => $value)->get($initialValue)
                     : collect($options)->get($initialValue) }}';
+
+                this.setHiddenInputValue(this.value, false);
             @endif
 
             this.$nextTick(() => {
@@ -60,8 +62,16 @@
 
             this.open = false;
 
+            this.setHiddenInputValue(value);
+        },
+        setHiddenInputValue: function(value, dispatchEvent = true) {
             const { input } = this.$refs;
+
             input.value = value
+
+            if (!dispatchEvent) {
+                return;
+            }
 
             const event = new Event('input', {
                 bubbles: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The rich select has a hidden input  that carries the selected value, this value is assigned every time the select changes but was not being  assigned for initial values

That problem was causing a bug in the advanced search on explorer: https://app.clickup.com/t/aeyr55

Fixed here 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
