### PR TITLE
feat: allow setting custom models on inputs

### DIFF
--- a/resources/views/inputs/input-with-icon.blade.php
+++ b/resources/views/inputs/input-with-icon.blade.php
@@ -12,7 +12,7 @@
                     type="{{ $type ?? 'text' }}"
                     id="{{ $id ?? $name }}"
                     class="{{ $inputClass ?? '' }} input-text-with-icon @error($name) input-text-with-icon--error @enderror"
-                    wire:model="{{ $model ?? $name }}"
+                    @unless($noModel ?? false) wire:model="{{ $model ?? $name }}" @endunless
                     {{-- @TODO: remove --}}
                     @isset($keydownEnter) wire:keydown.enter="{{ $keydownEnter }}" @endisset
                     {{-- @TODO: remove --}}

--- a/resources/views/inputs/input.blade.php
+++ b/resources/views/inputs/input.blade.php
@@ -10,7 +10,7 @@
                 type="{{ $type ?? 'text' }}"
                 id="{{ $id ?? $name }}"
                 class="input-text @error($name) input-text--error @enderror {{ $inputClass ?? '' }}"
-                wire:model="{{ $model ?? $name }}"
+                @unless($noModel ?? false) wire:model="{{ $model ?? $name }}" @endUnless
                 {{-- @TODO: remove --}}
                 @isset($keydownEnter) wire:keydown.enter="{{ $keydownEnter }}" @endisset
                 {{-- @TODO: remove --}}


### PR DESCRIPTION
This will allow overwriting the default `wire:model` binding by passing `no-model` to the input and using whatever binding you want, e.g.:

```
<x-ark-input
    type="text"
    :name="foo"
    no-model
    wire:model.lazy="bar"
/>
```