### PR TITLE
refactor: navbar notification icon tweaks

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -3,6 +3,10 @@
     @apply button-secondary p-0 flex items-center justify-center bg-transparent;
 }
 
+.dropdown-button-outline {
+    @apply dropdown-button border border-solid border-theme-secondary-200 rounded focus:bg-theme-primary-100;
+}
+
 .dropdown-entry {
     @apply flex w-full items-center font-medium text-left px-8 py-4 leading-5 transition duration-150 ease-in-out;
 }

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -1,4 +1,8 @@
 /** Dropdowns **/
+.dropdown-button {
+    @apply button-secondary p-0 flex items-center justify-center bg-transparent;
+}
+
 .dropdown-entry {
     @apply flex w-full items-center font-medium text-left px-8 py-4 leading-5 transition duration-150 ease-in-out;
 }

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -4,7 +4,11 @@
 }
 
 .dropdown-button-outline {
-    @apply dropdown-button border border-solid border-theme-secondary-200 rounded focus:bg-theme-primary-100;
+    @apply button-secondary p-0 flex items-center justify-center bg-transparent border border-solid border-theme-secondary-200 rounded;
+}
+
+.dropdown-button-outline:focus {
+    @apply bg-theme-primary-100;
 }
 
 .dropdown-entry {

--- a/resources/views/navbar/notifications.blade.php
+++ b/resources/views/navbar/notifications.blade.php
@@ -1,7 +1,7 @@
 <div @click="livewire.emit('markNotificationsAsSeen')">
-    <x-ark-dropdown wrapper-class="ml-3 sm:relative" dropdown-classes="mt-6 md:mt-8 {{ $dropdownClasses ?? '' }}">
+    <x-ark-dropdown wrapper-class="mx-3 sm:relative" dropdown-classes="mt-6 md:mt-8 {{ $dropdownClasses ?? '' }}">
         <x-slot name="button">
-            @svg('notification', 'h-6 w-6 transition-default')
+            @svg('notification', 'h-6 w-6 transition-default text-theme-secondary-400 hover:text-theme-primary-600')
 
             @isset($notificationsIndicator)
                 {{ $notificationsIndicator }}


### PR DESCRIPTION
## Summary

- Moved the `dropdown-button` class 
- Colors change for the notification icon within navbar
- Margin to recenter the notification icon

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged