### PR TITLE
feat: allow to override the icon wrapper

### DIFF
--- a/resources/views/details-box.blade.php
+++ b/resources/views/details-box.blade.php
@@ -1,5 +1,7 @@
 <div class="flex items-center space-x-5 detail-box">
-    @if(isset($icon) || isset($iconRaw))
+    @isset($iconWrapper)
+        {{ $iconWrapper }}
+    @elseif(isset($icon) || isset($iconRaw))
         @isset($shallow)
             <div class="flex-shrink-0 circled-icon text-theme-secondary-900 dark:text-theme-secondary-600 border-theme-secondary-900 dark:border-theme-secondary-600 {{ $iconWrapperClass ?? '' }}">
                 @if ($icon ?? false)
@@ -18,6 +20,7 @@
             </div>
         @endisset
     @endif
+
 
     <div class="flex flex-col space-y-2">
         <span class="text-sm font-semibold text-theme-secondary-500 dark:text-theme-secondary-700">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

For a feature in the nodem repository related to show a progress circle, I need to use a custom icon component that requires me to override the default icon wrapper on the `resources/views/details-box.blade.php` component.

Related to: https://github.com/ArkEcosystem/nodem/pull/46

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
