### PR TITLE
fix: highlight on firefox issue

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -145,6 +145,7 @@
 
 .table-container table > tbody > tr > td.hoverable-cell > div {
     @apply box-content relative flex items-center h-full px-3 py-4;
+    -moz-box-sizing: border-box;
 }
 
 .table-container table > tbody > tr > td.hoverable-cell.text-right > div {

--- a/resources/views/tables/cell.blade.php
+++ b/resources/views/tables/cell.blade.php
@@ -31,7 +31,7 @@
 ]) }}
     @if ($colspan) colspan="{{ $colspan }}" @endif
 >
-    <div class="relative flex items-center h-full px-3 py-4">
+    <div>
         {{ $slot }}
     </div>
 </td>

--- a/resources/views/tables/row.blade.php
+++ b/resources/views/tables/row.blade.php
@@ -2,6 +2,6 @@
     'danger' => false,
     'warning' => false,
 ])
-<tr {{ $attributes }} @if($danger) data-danger @elseif($warning) data-warning @endif>
+<tr {{ $attributes }} @if($danger) data-danger @elseif($warning) data-warning @endif class="h-full">
     {{ $slot }}
 </tr>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Add necessary classes and styles to make the highlighted rows look ok on firefox
- The classes removed from the cells are also defined on the _tables.css file, so there are not necessary
- Tested on safari, chrome, and firefox


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->
