### PR TITLE
feat: remove ring classes from dropdowns

### DIFF
--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -34,7 +34,7 @@
         class="origin-top-right absolute right-0 mt-2 rounded-md shadow-lg z-10 dropdown {{ $dropdownClasses ?? 'w-40' }}"
         @if ($height ?? false) data-height="{{ $height }}" @endif
     >
-        <div class="bg-white rounded-md ring-1 ring-black ring-opacity-5 dark:bg-theme-secondary-800 dark:text-theme-secondary-200" x-cloak>
+        <div class="bg-white rounded-md dark:bg-theme-secondary-800 dark:text-theme-secondary-200" x-cloak>
             <div class="py-1" @if($closeOnClick ?? true) @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif>
                 {{ $slot }}
             </div>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -34,7 +34,7 @@
         class="origin-top-right absolute right-0 mt-2 rounded-md shadow-lg z-10 dropdown {{ $dropdownClasses ?? 'w-40' }}"
         @if ($height ?? false) data-height="{{ $height }}" @endif
     >
-        <div class="bg-white rounded-md dark:bg-theme-secondary-800 dark:text-theme-secondary-200" x-cloak>
+        <div class="bg-white rounded-md shadow-lg dark:bg-theme-secondary-800 dark:text-theme-secondary-200" x-cloak>
             <div class="py-1" @if($closeOnClick ?? true) @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif>
                 {{ $slot }}
             </div>

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -199,7 +199,7 @@ $initialText = $grouped
             tabindex="-1"
             role="listbox"
             aria-labelledby="listbox-label"
-            class="py-3 overflow-auto bg-white rounded-md ring-1 ring-black ring-opacity-5 outline-none dark:bg-theme-secondary-800 dark:text-theme-secondary-200 hover:outline-none {{ $dropdownListClass }}"
+            class="py-3 overflow-auto bg-white rounded-md outline-none dark:bg-theme-secondary-800 dark:text-theme-secondary-200 hover:outline-none {{ $dropdownListClass }}"
         >
             @isset($dropdownList)
                 {{ $dropdownList }}

--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -199,7 +199,7 @@ $initialText = $grouped
             tabindex="-1"
             role="listbox"
             aria-labelledby="listbox-label"
-            class="py-3 overflow-auto bg-white rounded-md outline-none dark:bg-theme-secondary-800 dark:text-theme-secondary-200 hover:outline-none {{ $dropdownListClass }}"
+            class="py-3 overflow-auto bg-white rounded-md outline-none dark:bg-theme-secondary-800 shadow-lg dark:text-theme-secondary-200 hover:outline-none {{ $dropdownListClass }}"
         >
             @isset($dropdownList)
                 {{ $dropdownList }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/ayubjz

The ticket mentions only the server dropdown that comes from the dropdown component so the change will affect every dropdown we have but that is correct since the design and the style guide consider a shadow instead of the border as far as I can tell.

Same for the rich select component, it has a ring but in any of the designs, we have that border.

Tested on different projects and looks fine but there may be a dropdown hidden there that may be affected visually speaking, if that is the case I think that the hypothetically dropdown can be fixed individually

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
