### PR TITLE
refactor: added chevron next to view all within slider component

### DIFF
--- a/resources/lang/en/actions.php
+++ b/resources/lang/en/actions.php
@@ -4,4 +4,5 @@ return [
     'discord'       => 'Discord',
     'documentation' => 'Documentation',
     'send'          => 'Send',
+    'view_all'      => 'View all',
 ];

--- a/resources/views/slider.blade.php
+++ b/resources/views/slider.blade.php
@@ -16,7 +16,10 @@
             @if ($viewAllUrl ?? false)
                 <div class="flex {{ $viewAllClass ?? '' }}">
                     <div class="flex-1 my-auto text-sm text-right">
-                        <a href="{{ $viewAllUrl }}" class="link">View all</a>
+                        <a href="{{ $viewAllUrl }}" class="link">
+                            @lang('ui::actions.view_all')
+                            <x-ark-icon class="inline-block" name="chevron-right" size="2xs" />
+                        </a>
                     </div>
                 </div>
             @endif


### PR DESCRIPTION
## Summary

Designs were showing a chevron with a right direction next to the `View all` within sliders. Also localized that action.

![](https://gyazo.com/47b99347c2ba2354127d51482a6fa4ad.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged