### PR TITLE
fix: use links in pagination url and fix form parameters

### DIFF
--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -71,7 +71,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -80,7 +80,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -1,5 +1,6 @@
 @php
-['path' => $path, 'pageName' => $pageName] =    $paginator->getOptions();
+['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
+$urlParams = Arr::except(request()->all(), [$pageName]);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -7,7 +8,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,9 +16,12 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
+            @foreach($urlParams as $key => $value)
+            <input type="hidden" name="{{ $key }}" value="{{ $value }}" />
+            @endforeach
             <button type="submit" class="p-2 text-theme-secondary-500 hover:text-theme-primary-500 transition-default dark:text-theme-secondary-200" :disabled="!page">
                 <x-ark-icon name="search" size="sm" />
             </button>
@@ -34,24 +38,40 @@
     </div>
 
     <div class="flex space-x-3">
-        <button
-            wire:click="gotoPage(1)"
-            class="items-center button-secondary pagination-button-mobile" @if($paginator->onFirstPage()) disabled @endif
-        >
-            <x-ark-icon name="pagination-first" size="xs" />
-        </button>
-        <button
-            wire:click="gotoPage({{ $paginator->currentPage() - 1 }})"
-            class="items-center button-secondary pagination-button-mobile" @if($paginator->onFirstPage()) disabled @endif
-        >
-            <div class="flex items-center">
-                <x-ark-icon class="inline-block lg:hidden" name="chevron-left" size="xs" />
-                <span class="hidden lg:flex">Previous</span>
+        @if($paginator->onFirstPage())
+            <div class="flex items-center button-generic button-disabled">
+                <span class="flex items-center">
+                    <x-ark-icon name="pagination-first" size="xs" />
+                </span>
             </div>
-        </button>
+        @else
+            <a class="flex" href="{{ $paginator->url(1) }}">
+                <div class="flex items-center h-full button-secondary pagination-button-mobile">
+                    <span class="flex items-center">
+                        <x-ark-icon name="pagination-first" size="xs" />
+                    </span>
+                </div>
+            </a>
+        @endif
+
+        @if($paginator->onFirstPage())
+            <div class="flex items-center button-generic button-disabled">
+                <div class="flex items-center">
+                    <span class="hidden lg:flex lg:ml-2">Previous</span>
+                </div>
+            </div>
+        @else
+            <a class="flex" href="{{ $paginator->previousPageUrl() }}">
+                <div class="flex items-center h-full button-secondary pagination-button-mobile">
+                    <div class="flex items-center">
+                        <span class="hidden lg:flex lg:ml-2">Previous</span>
+                    </div>
+                </div>
+            </a>
+        @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -60,9 +80,12 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
+                @foreach($urlParams as $key => $value)
+                <input type="hidden" name="{{ $key }}" value="{{ $value }}" />
+                @endforeach
                 <button type="submit" class="p-2 text-theme-secondary-500 hover:text-theme-primary-500 transition-default dark:text-theme-secondary-200" :disabled="!page">
                     <x-ark-icon name="search" size="sm" />
                 </button>
@@ -89,12 +112,12 @@
                     {{-- Array Of Links --}}
                     @if (is_array($element))
                         @foreach ($element as $page => $url)
-                            <button
+                            <a
+                                href="{{ $url }}"
                                 class="@if ($paginator->currentPage() === $page) button-pagination-page-indicator--selected @else button-pagination-page-indicator  @endif"
-                                wire:click="gotoPage({{ $page }})"
                             >
                                 {{ $page }}
-                            </button>
+                            </a>
                         @endforeach
                     @endif
                 @endforeach
@@ -110,21 +133,36 @@
             </div>
         </div>
 
-        <button
-            wire:click="gotoPage({{ $paginator->currentPage() + 1 }})"
-            class="items-center button-secondary pagination-button-mobile" @if($paginator->currentPage() === $paginator->lastPage()) disabled @endif
-        >
-            <div class="flex items-center">
-                <span class="hidden lg:flex">Next</span>
-                <x-ark-icon class="inline-block lg:hidden" name="chevron-right" size="xs" />
+        @if($paginator->hasMorePages())
+            <a class="flex" href="{{ $paginator->nextPageUrl() }}">
+                <div class="flex items-center h-full button-secondary pagination-button-mobile">
+                    <div class="flex items-center">
+                        <span class="hidden lg:flex lg:mr-2">Next</span>
+                    </div>
+                </div>
+            </a>
+        @else
+            <div class="flex items-center button-generic button-disabled">
+                <div class="flex items-center">
+                    <span class="hidden lg:flex lg:mr-2">Next</span>
+                </div>
             </div>
-        </button>
-        <button
-            wire:click="gotoPage({{ $paginator->lastPage() }})"
-            class="items-center button-secondary pagination-button-mobile"
-            @if($paginator->currentPage() === $paginator->lastPage()) disabled @endif
-        >
-            <x-ark-icon name="pagination-last" size="xs" />
-        </button>
+        @endif
+
+        @if($paginator->hasMorePages())
+            <a class="flex" href="{{ $paginator->url($paginator->lastPage()) }}">
+                <div class="flex items-center h-full button-secondary pagination-button-mobile">
+                    <span class="flex items-center">
+                        <x-ark-icon name="pagination-last" size="xs" />
+                    </span>
+                </div>
+            </a>
+        @else
+            <div class="flex items-center button-generic button-disabled">
+                <span class="flex items-center">
+                    <x-ark-icon name="pagination-last" size="xs" />
+                </span>
+            </div>
+        @endif
     </div>
 </div>

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,5 +1,6 @@
 @php
-['path' => $path, 'pageName' => $pageName] =    $paginator->getOptions();
+['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
+$urlParams = Arr::except(request()->all(), [$pageName]);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -7,7 +8,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,9 +16,12 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
+            @foreach($urlParams as $key => $value)
+            <input type="hidden" name="{{ $key }}" value="{{ $value }}" />
+            @endforeach
             <button type="submit" class="p-2 text-theme-secondary-500 hover:text-theme-primary-500 transition-default dark:text-theme-secondary-200" :disabled="!page">
                 <x-ark-icon name="search" size="sm" />
             </button>
@@ -53,7 +57,7 @@
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -62,9 +66,12 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
+                @foreach($urlParams as $key => $value)
+                <input type="hidden" name="{{ $key }}" value="{{ $value }}" />
+                @endforeach
                 <button type="submit" class="p-2 text-theme-secondary-500 hover:text-theme-primary-500 transition-default dark:text-theme-secondary-200" :disabled="!page">
                     <x-ark-icon name="search" size="sm" />
                 </button>

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -57,7 +57,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -66,7 +66,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes two different problems:

1. When using the form to put the page number manually, the request lost the rest of the query parameters. In other words, if you have, let's say, a search `page?search=2` and change the page with the form, the URL will be lost the `search` query param.

2. The `pagination-url` is using buttons instead of the link, so it's not working 

**Note:** All the projects have local views for the pagination so even if this is merged it will not solve the issue until we update those files, however, only the ones that use pagination-url or `get` parameters on the paginated page should be affected. I will wait until this is merged to update the rest of the projects.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
