### PR TITLE
fix: the parameters for the pagination should come only from the query

### DIFF
--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -71,7 +71,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -80,7 +80,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -1,6 +1,6 @@
 @php
 ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
-$urlParams = Arr::except(request()->all(), [$pageName]);
+$urlParams = Arr::except(request()->query(), [$pageName]);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -71,7 +71,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -80,7 +80,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -1,14 +1,5 @@
 @php
-['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
-$urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
-    ->mapWithKeys(function ($value, $key) {
-        $parts = explode('.', $key);
-        // Add square brackets to the query param when needed, example: `state['all']=1`
-        $key = collect($parts)
-            ->slice(1)
-            ->reduce(fn ($key, $part) => $key . '[' . $part . ']', $parts[0]);
-        return [$key => $value];
-    });
+['path' => $path, 'pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,6 +1,6 @@
 @php
 ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
-$urlParams = Arr::except(request()->all(), [$pageName]);
+$urlParams = Arr::except(request()->query(), [$pageName]);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -57,7 +57,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -66,7 +66,7 @@ $urlParams = Arr::except(request()->all(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -8,7 +8,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +16,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -57,7 +57,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -66,7 +66,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,6 +1,14 @@
 @php
 ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
-$urlParams = Arr::except(request()->query(), [$pageName]);
+$urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
+    ->mapWithKeys(function ($value, $key) {
+        $parts = explode('.', $key);
+        // Add square brackets to the query param when needed, example: `state['all']=1`
+        $key = collect($parts)
+            ->slice(1)
+            ->reduce(fn ($key, $part) => $key . '[' . $part . ']', $parts[0]);
+        return [$key => $value];
+    });
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -8,7 +16,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -16,7 +24,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -57,7 +65,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -66,7 +74,7 @@ $urlParams = Arr::except(request()->query(), [$pageName]);
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,14 +1,5 @@
 @php
-['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
-$urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
-    ->mapWithKeys(function ($value, $key) {
-        $parts = explode('.', $key);
-        // Add square brackets to the query param when needed, example: `state['all']=1`
-        $key = collect($parts)
-            ->slice(1)
-            ->reduce(fn ($key, $part) => $key . '[' . $part . ']', $parts[0]);
-        return [$key => $value];
-    });
+['path' => $path, 'pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"

--- a/src/UI.php
+++ b/src/UI.php
@@ -30,11 +30,11 @@ class UI
     {
         ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
 
-        // Extract the query params to be used on the page form
+        // Extracts the query params that will be added to the page form
         $urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
             ->mapWithKeys(function ($value, $key) {
                 $parts = explode('.', $key);
-                // Add square brackets to the query params when needed, example: `state['all']=1`
+                // Add square brackets to the query params when needed, example: `&state['all']=1`
                 $key = collect($parts)
                     ->slice(1)
                     ->reduce(fn ($key, $part) => $key . '[' . $part . ']', $parts[0]);

--- a/src/UI.php
+++ b/src/UI.php
@@ -2,6 +2,9 @@
 
 namespace ARKEcosystem\UserInterface;
 
+use Illuminate\Support\Arr;
+use Illuminate\Pagination\AbstractPaginator;
+
 class UI
 {
     private static array $errorMessages = [];
@@ -21,5 +24,24 @@ class UI
     public static function useErrorMessage(int $code, string $message): void
     {
         static::$errorMessages[$code] = $message;
+    }
+
+    public static function getPaginationData(AbstractPaginator $paginator): array
+    {
+        ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
+
+        // Extract the query params to be used on the page form
+        $urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
+            ->mapWithKeys(function ($value, $key) {
+                $parts = explode('.', $key);
+                // Add square brackets to the query params when needed, example: `state['all']=1`
+                $key = collect($parts)
+                    ->slice(1)
+                    ->reduce(fn ($key, $part) => $key . '[' . $part . ']', $parts[0]);
+
+                return [$key => $value];
+            });
+
+        return compact('path', 'pageName', 'urlParams');
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Two problems:

1. Some test is failing because the pagination used all the request parameters to fill the hidden input, that was wrong we should only use the GET params
2. The pagination form doesn't handle well the nested parameters like `&type[state]=something`, also fixed

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
