### PR TITLE
fix: remove path that has conflicts with livewire

### DIFF
--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -7,7 +7,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,7 +15,7 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -70,7 +70,7 @@
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -79,7 +79,7 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -1,5 +1,5 @@
 @php
-['path' => $path, 'pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
+['pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -7,7 +7,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,7 +15,7 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -70,7 +70,7 @@
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -79,7 +79,7 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,5 +1,5 @@
 @php
-['path' => $path, 'pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
+['pageName' => $pageName, 'urlParams' => $urlParams] = ARKEcosystem\UserInterface\UI::getPaginationData($paginator);
 @endphp
 <div
     x-data="Pagination('{{ $pageName }}', {{ $paginator->lastPage() }})"
@@ -7,7 +7,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,7 +15,7 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -56,7 +56,7 @@
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" action="{{ $path }}" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -65,7 +65,7 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
+                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -7,7 +7,7 @@
     class="pagination-wrapper"
 >
     <div class="relative pagination-pages-mobile">
-        <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
+        <form x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800">
             <input
                 x-model.number="page"
                 type="number"
@@ -15,7 +15,7 @@
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
                 placeholder="Enter the page"
-                class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
             @foreach($urlParams as $key => $value)
@@ -56,7 +56,7 @@
         </button>
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" class="absolute left-0 z-10 flex w-full h-full px-2 overflow-hidden rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
+            <form x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 dark:bg-theme-secondary-800 pagination-form-desktop">
                 <input
                     x-ref="search"
                     x-model.number="page"
@@ -65,7 +65,7 @@
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
                     placeholder="Enter the page number"
-                    class="w-full px-3 py-2 bg-transparent dark:text-theme-secondary-200"
+                    class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />
                 @foreach($urlParams as $key => $value)

--- a/src/UI.php
+++ b/src/UI.php
@@ -28,7 +28,7 @@ class UI
 
     public static function getPaginationData(AbstractPaginator $paginator): array
     {
-        ['path' => $path, 'pageName' => $pageName] = $paginator->getOptions();
+        ['pageName' => $pageName] = $paginator->getOptions();
 
         // Extracts the query params that will be added to the page form
         $urlParams = collect(Arr::dot(Arr::except(request()->query(), [$pageName])))
@@ -42,6 +42,6 @@ class UI
                 return [$key => $value];
             });
 
-        return compact('path', 'pageName', 'urlParams');
+        return compact('pageName', 'urlParams');
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

As always, after merge ill need to update all the projects pagination scripts again
-->

## Summary

Encounter an issue when the users try to change the pagination page with the form. The issue is that the form `action` comes from the pagination data that in livewire points to a livewire route and not the current route.

To replicate:

1. Change the page with the page buttons
2. Once updated, try to change the page with the form.

That path was never really necessary, and just remove it solves the problem since the default form action is the current page.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
