### PR TITLE
fix: prevent contact form re-submission

### DIFF
--- a/resources/views/pages/contact/content.blade.php
+++ b/resources/views/pages/contact/content.blade.php
@@ -21,7 +21,7 @@
                 <span class="font-semibold leading-none text-center">@lang('ui::general.or')</span>
 
                 <a href="{{ $discordUrl ?? trans('ui::urls.discord') }}" target="_blank" rel="noopener nofollow noreferrer" class="button-secondary">
-                    <div class="flex items-center justify-center w-full space-x-2">
+                    <div class="flex justify-center items-center space-x-2 w-full">
                         @svg('brands.discord', 'w-5 h-5')
                         <span>@lang('ui::actions.discord')</span>
                     </div>
@@ -113,7 +113,7 @@
                     error: {{ (flash()->level === 'error') ? 'true' : 'false' }}
                 }"
                 x-init="setTimeout(() => { error = false; success = false }, 10000)"
-                class="relative flex flex-col justify-end flex-1"
+                class="flex relative flex-col flex-1 justify-end"
             >
                 <div x-show.transition="success" class="absolute top-0 w-full" x-cloak>
                     <x-ark-toast

--- a/resources/views/pages/contact/content.blade.php
+++ b/resources/views/pages/contact/content.blade.php
@@ -21,7 +21,7 @@
                 <span class="font-semibold leading-none text-center">@lang('ui::general.or')</span>
 
                 <a href="{{ $discordUrl ?? trans('ui::urls.discord') }}" target="_blank" rel="noopener nofollow noreferrer" class="button-secondary">
-                    <div class="flex justify-center items-center space-x-2 w-full">
+                    <div class="flex items-center justify-center w-full space-x-2">
                         @svg('brands.discord', 'w-5 h-5')
                         <span>@lang('ui::actions.discord')</span>
                     </div>
@@ -45,7 +45,7 @@
         <h3>@lang('ui::pages.contact.form.title')</h3>
         <div class="mt-4">@lang('ui::pages.contact.form.description')</div>
 
-        <form method="POST" action="{{ route('contact') }}" class="flex flex-col flex-1 space-y-8" enctype="multipart/form-data">
+        <form id="contact-form" method="POST" action="{{ route('contact') }}#contact-form" class="flex flex-col flex-1 space-y-8" enctype="multipart/form-data">
             @csrf
 
             @honeypot
@@ -113,7 +113,7 @@
                     error: {{ (flash()->level === 'error') ? 'true' : 'false' }}
                 }"
                 x-init="setTimeout(() => { error = false; success = false }, 10000)"
-                class="flex relative flex-col flex-1 justify-end"
+                class="relative flex flex-col justify-end flex-1"
             >
                 <div x-show.transition="success" class="absolute top-0 w-full" x-cloak>
                     <x-ark-toast

--- a/src/Http/Controllers/ContactController.php
+++ b/src/Http/Controllers/ContactController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
 
 final class ContactController extends Controller
 {
@@ -36,7 +37,7 @@ final class ContactController extends Controller
         return view('app.contact', compact('message', 'subject'));
     }
 
-    public function handle(Request $request): View
+    public function handle(Request $request): RedirectResponse
     {
         $data = $request->validate([
             'name'       => ['required', 'max:64'],
@@ -63,7 +64,7 @@ final class ContactController extends Controller
 
         flash()->success(trans('messages.contact'));
 
-        return view('app.contact');
+        return redirect()->route('contact');
     }
 
     private function getSubjects(): Collection


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

1. Since the contact form controller returns the contact view if I refresh the page it re-submit the form data and it sends the email again so I change to use a redirect instead.

2. Plus, after a contact form submission the user scroll is at the top of the page so unless the user scrolls down and looks for the success message it can be easily lost. Added an anchor to send the user to the contact form again after submission.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
