### PR TITLE
feat: readonly option for image upload

### DIFF
--- a/resources/views/inputs/upload-image.blade.php
+++ b/resources/views/inputs/upload-image.blade.php
@@ -25,36 +25,32 @@
             <input
                 id="photo"
                 type="file"
-                class="block hidden absolute top-0 opacity-0 cursor-pointer"
+                class="absolute top-0 hidden block opacity-0 cursor-pointer"
                 wire:model="photo"
                 accept="image/jpg,image/jpeg,image/bmp,image/png"
             />
             @endunless
         </div>
 
-        @if ($readonly)
-
-        @else
-            @unless ($image)
-                <div
-                    wire:key="upload-button"
-                    class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
-                    role="button"
-                >
-                    <div class="text-theme-primary-500">
-                        <x-ark-icon name="upload-cloud" size="lg" />
-                    </div>
-
-                    <div class="font-semibold text-theme-secondary-900">{{ $uploadText }}</div>
-
-                    <div class="text-xs font-semibold text-theme-secondary-500">
-                        @lang('ui::forms.upload-image.min_size', [$minWidth, $minHeight])
-                    </div>
-                    <div class="text-xs font-semibold text-theme-secondary-500">
-                        @lang('ui::forms.upload-image.max_filesize', [$maxFilesize])
-                    </div>
+        @if (!$image && !$readonly)
+            <div
+                wire:key="upload-button"
+                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                role="button"
+            >
+                <div class="text-theme-primary-500">
+                    <x-ark-icon name="upload-cloud" size="lg" />
                 </div>
-            @endunless
+
+                <div class="font-semibold text-theme-secondary-900">{{ $uploadText }}</div>
+
+                <div class="text-xs font-semibold text-theme-secondary-500">
+                    @lang('ui::forms.upload-image.min_size', [$minWidth, $minHeight])
+                </div>
+                <div class="text-xs font-semibold text-theme-secondary-500">
+                    @lang('ui::forms.upload-image.max_filesize', [$maxFilesize])
+                </div>
+            </div>
         @endif
 
 
@@ -77,7 +73,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
         </div>
         @endunless
     </div>

--- a/resources/views/inputs/upload-image.blade.php
+++ b/resources/views/inputs/upload-image.blade.php
@@ -6,6 +6,7 @@
     'minWidth'      => 148,
     'minHeight'     => 148,
     'maxFilesize'   => '2MB',
+    'readonly'      => false,
 ])
 
 <div class="relative">
@@ -14,40 +15,50 @@
             @if ($image)
                 style="background-image: url('{{ $image }}')"
             @endif
-            class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl cursor-pointer bg-theme-primary-50 hover:bg-theme-primary-100 transition-default"
+            class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl bg-theme-primary-50 @unless($readonly) cursor-pointer hover:bg-theme-primary-100 transition-default @endunless"
+            @unless($readonly)
             @click="select()"
             role="button"
+            @endunless
         >
+            @unless($readonly)
             <input
                 id="photo"
                 type="file"
-                class="block hidden absolute top-0 opacity-0 cursor-pointer"
+                class="absolute top-0 hidden block opacity-0 cursor-pointer"
                 wire:model="photo"
                 accept="image/jpg,image/jpeg,image/bmp,image/png"
             />
+            @endunless
         </div>
 
-        @unless ($image)
-            <div
-                wire:key="upload-button"
-                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
-                role="button"
-            >
-                <div class="text-theme-primary-500">
-                    <x-ark-icon name="upload-cloud" size="lg" />
-                </div>
+        @if ($readonly)
 
-                <div class="font-semibold text-theme-secondary-900">{{ $uploadText }}</div>
+        @else
+            @unless ($image)
+                <div
+                    wire:key="upload-button"
+                    class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                    role="button"
+                >
+                    <div class="text-theme-primary-500">
+                        <x-ark-icon name="upload-cloud" size="lg" />
+                    </div>
 
-                <div class="text-xs font-semibold text-theme-secondary-500">
-                    @lang('ui::forms.upload-image.min_size', [$minWidth, $minHeight])
-                </div>
-                <div class="text-xs font-semibold text-theme-secondary-500">
-                    @lang('ui::forms.upload-image.max_filesize', [$maxFilesize])
-                </div>
-            </div>
-        @endunless
+                    <div class="font-semibold text-theme-secondary-900">{{ $uploadText }}</div>
 
+                    <div class="text-xs font-semibold text-theme-secondary-500">
+                        @lang('ui::forms.upload-image.min_size', [$minWidth, $minHeight])
+                    </div>
+                    <div class="text-xs font-semibold text-theme-secondary-500">
+                        @lang('ui::forms.upload-image.max_filesize', [$maxFilesize])
+                    </div>
+                </div>
+            @endunless
+        @endif
+
+
+        @unless($readonly)
         <div
             wire:key="delete-button"
             class="rounded-xl absolute top-0 opacity-0 hover:opacity-100 transition-default {{ $dimensions }}
@@ -66,7 +77,8 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
         </div>
+        @endunless
     </div>
 </div>

--- a/resources/views/inputs/upload-image.blade.php
+++ b/resources/views/inputs/upload-image.blade.php
@@ -25,7 +25,7 @@
             <input
                 id="photo"
                 type="file"
-                class="absolute top-0 hidden block opacity-0 cursor-pointer"
+                class="block hidden absolute top-0 opacity-0 cursor-pointer"
                 wire:model="photo"
                 accept="image/jpg,image/jpeg,image/bmp,image/png"
             />
@@ -38,7 +38,7 @@
             @unless ($image)
                 <div
                     wire:key="upload-button"
-                    class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                    class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
                     role="button"
                 >
                     <div class="text-theme-primary-500">
@@ -77,7 +77,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
         </div>
         @endunless
     </div>

--- a/resources/views/inputs/upload-image.blade.php
+++ b/resources/views/inputs/upload-image.blade.php
@@ -25,7 +25,7 @@
             <input
                 id="photo"
                 type="file"
-                class="absolute top-0 hidden block opacity-0 cursor-pointer"
+                class="block hidden absolute top-0 opacity-0 cursor-pointer"
                 wire:model="photo"
                 accept="image/jpg,image/jpeg,image/bmp,image/png"
             />
@@ -35,7 +35,7 @@
         @if (!$image && !$readonly)
             <div
                 wire:key="upload-button"
-                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
                 role="button"
             >
                 <div class="text-theme-primary-500">
@@ -73,7 +73,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
         </div>
         @endunless
     </div>

--- a/resources/views/inputs/upload-image.blade.php
+++ b/resources/views/inputs/upload-image.blade.php
@@ -17,18 +17,18 @@
             @endif
             class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl bg-theme-primary-50 @unless($readonly) cursor-pointer hover:bg-theme-primary-100 transition-default @endunless"
             @unless($readonly)
-            @click="select()"
-            role="button"
+                @click="select()"
+                role="button"
             @endunless
         >
             @unless($readonly)
-            <input
-                id="photo"
-                type="file"
-                class="block hidden absolute top-0 opacity-0 cursor-pointer"
-                wire:model="photo"
-                accept="image/jpg,image/jpeg,image/bmp,image/png"
-            />
+                <input
+                    id="photo"
+                    type="file"
+                    class="block hidden absolute top-0 opacity-0 cursor-pointer"
+                    wire:model="photo"
+                    accept="image/jpg,image/jpeg,image/bmp,image/png"
+                />
             @endunless
         </div>
 
@@ -55,26 +55,26 @@
 
 
         @unless($readonly)
-        <div
-            wire:key="delete-button"
-            class="rounded-xl absolute top-0 opacity-0 hover:opacity-100 transition-default {{ $dimensions }}
-                @unless ($image) hidden @endunless"
-
-        >
-            <div class="pointer-events-none rounded-xl absolute top-0 opacity-70 border-6 border-theme-secondary-900 transition-default {{ $dimensions }}"></div>
-
             <div
-                class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
-                wire:click="delete"
-                data-tippy-hover="{{ $deleteTooltip }}"
-            >
-                <x-ark-icon name="close" size="sm" />
-            </div>
-        </div>
+                wire:key="delete-button"
+                class="rounded-xl absolute top-0 opacity-0 hover:opacity-100 transition-default {{ $dimensions }}
+                    @unless ($image) hidden @endunless"
 
-        <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
-        </div>
+            >
+                <div class="pointer-events-none rounded-xl absolute top-0 opacity-70 border-6 border-theme-secondary-900 transition-default {{ $dimensions }}"></div>
+
+                <div
+                    class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
+                    wire:click="delete"
+                    data-tippy-hover="{{ $deleteTooltip }}"
+                >
+                    <x-ark-icon name="close" size="sm" />
+                </div>
+            </div>
+
+            <div x-show="isUploading" x-cloak>
+                <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            </div>
         @endunless
     </div>
 </div>

--- a/src/Components/UploadImage.php
+++ b/src/Components/UploadImage.php
@@ -17,6 +17,8 @@ abstract class UploadImage extends Component
 
     public $dimensions;
 
+    public $readonly = false;
+
     abstract public function render();
 
     abstract public function store();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The upload image component now has a readonly prop that hides everything related to replace/remove the current photo

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
