### PR TITLE
feat: slot to add content in the middle of the navbar

### DIFF
--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -20,7 +20,7 @@
 
     <nav class="relative z-30 bg-white shadow-header-smooth dark:shadow-none dark:bg-theme-secondary-900">
         <div class="px-4 sm:px-6 lg:px-8">
-            <div class="relative flex justify-between h-20 md:h-24">
+            <div class="flex relative justify-between h-20 md:h-24">
                 @include('ark::navbar.logo')
 
                 @isset($middle)
@@ -28,7 +28,7 @@
                 @endisset
 
                 <div class="flex justify-end">
-                    <div class="flex items-center justify-end flex-1 sm:items-stretch sm:justify-between">
+                    <div class="flex flex-1 justify-end items-center sm:items-stretch sm:justify-between">
                         @isset($desktop)
                             {{ $desktop }}
                         @else
@@ -36,7 +36,7 @@
                         @endisset
                     </div>
 
-                    <div class="inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
+                    <div class="flex inset-y-0 right-0 items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
                         @include('ark::navbar.hamburger')
 
                         @isset($content)

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -20,11 +20,15 @@
 
     <nav class="relative z-30 bg-white shadow-header-smooth dark:shadow-none dark:bg-theme-secondary-900">
         <div class="px-4 sm:px-6 lg:px-8">
-            <div class="flex relative justify-between h-20 md:h-24">
+            <div class="relative flex justify-between h-20 md:h-24">
                 @include('ark::navbar.logo')
 
+                @isset($middle)
+                    {{ $middle }}
+                @endisset
+
                 <div class="flex justify-end">
-                    <div class="flex flex-1 justify-end items-center sm:items-stretch sm:justify-between">
+                    <div class="flex items-center justify-end flex-1 sm:items-stretch sm:justify-between">
                         @isset($desktop)
                             {{ $desktop }}
                         @else
@@ -32,7 +36,7 @@
                         @endisset
                     </div>
 
-                    <div class="flex inset-y-0 right-0 items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
+                    <div class="inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
                         @include('ark::navbar.hamburger')
 
                         @isset($content)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

In order to add the search icon that is in the new search design, I need a new slot on the navbar 
![image](https://user-images.githubusercontent.com/17262776/105402907-e6272a00-5c1f-11eb-8afb-b214eef793e6.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
