### PR TITLE
feat: accept `ins` tag on the markdown caster

### DIFF
--- a/src/Casts/Markdown.php
+++ b/src/Casts/Markdown.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 final class Markdown implements CastsAttributes
 {
+    protected array $allowedTags = ['ins'];
+
     /**
      * Cast the given value.
      *
@@ -33,8 +35,20 @@ final class Markdown implements CastsAttributes
      *
      * @return string
      */
-    public function set($model, $key, $value, $attributes)
+    public function set($model, $key, $value, $attributes): string
     {
-        return htmlentities(strip_tags($value));
+        $allowedTagsStr = '<' . implode('><', $this->allowedTags) . '>';
+
+        return $this->rollbackEncodedAllowedTags(htmlentities(strip_tags($value, $allowedTagsStr)));
+    }
+
+    private function rollbackEncodedAllowedTags(string $text): string
+    {
+        foreach ($this->allowedTags as $tag) {
+            $text = str_replace('&lt;' . $tag . '&gt;', '<' . $tag . '>', $text);
+            $text = str_replace('&lt;/' . $tag . '&gt;', '</' . $tag . '>', $text);
+        }
+
+        return $text;
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

https://app.clickup.com/t/crz75r

The markdown extension doesn't really filter the HTML attributes that is being done in a custom Markdown caster. This PR adds the `<ins>` tag as an allowed attribute while keeping the same security filters.

Build the code in a way we can add more allowed tags in the future.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
