### PR TITLE
chore: dont show the mobile until menu scripts loaded

### DIFF
--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -13,14 +13,14 @@
     ][$breakpoint];
 @endphp
 
-<div :class="{'block': open, 'hidden': !open}" class="border-t-2 border-theme-secondary-200 {{ $breakpointClass }}">
+<div x-cloak :class="{'block': open, 'hidden': !open}" class="border-t-2 border-theme-secondary-200 {{ $breakpointClass }}">
     <div class="pt-2 pb-4 rounded-b-lg">
         @if(isset($navbarNotificationsMobile) || isset($notifications))
             <div class="flex items-center justify-center px-2 py-0.5 mx-8 my-4 border rounded shadow-sm border-theme-secondary-300 md:hidden">
                 {{ $navbarNotificationsMobile }}
 
                 @if(isset($navbarNotificationsMobile) && isset($notifications))
-                    <span class="mx-4 h-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
+                    <span class="h-5 mx-4 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
                 @endif
 
                 @isset($notifications)
@@ -32,10 +32,10 @@
         @foreach ($navigation as $navItem)
             @if(isset($navItem['children']))
                 <div class="flex w-full">
-                    <div class="z-10 -mr-1 w-2"></div>
+                    <div class="z-10 w-2 -mr-1"></div>
                     <a
                         href="#"
-                        class="flex justify-between items-center py-3 px-8 w-full font-semibold border-l-2 border-transparent"
+                        class="flex items-center justify-between w-full px-8 py-3 font-semibold border-l-2 border-transparent"
                         @click="openDropdown = openDropdown === '{{ $navItem['label'] }}' ? null : '{{ $navItem['label'] }}'"
                     >
                         <span :class="{ 'text-theme-primary-600': openDropdown === '{{ $navItem['label'] }}' }">{{ $navItem['label'] }}</span>

--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -20,7 +20,7 @@
                 {{ $navbarNotificationsMobile }}
 
                 @if(isset($navbarNotificationsMobile) && isset($notifications))
-                    <span class="h-5 mx-4 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
+                    <span class="mx-4 h-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
                 @endif
 
                 @isset($notifications)
@@ -32,10 +32,10 @@
         @foreach ($navigation as $navItem)
             @if(isset($navItem['children']))
                 <div class="flex w-full">
-                    <div class="z-10 w-2 -mr-1"></div>
+                    <div class="z-10 -mr-1 w-2"></div>
                     <a
                         href="#"
-                        class="flex items-center justify-between w-full px-8 py-3 font-semibold border-l-2 border-transparent"
+                        class="flex justify-between items-center py-3 px-8 w-full font-semibold border-l-2 border-transparent"
                         @click="openDropdown = openDropdown === '{{ $navItem['label'] }}' ? null : '{{ $navItem['label'] }}'"
                     >
                         <span :class="{ 'text-theme-primary-600': openDropdown === '{{ $navItem['label'] }}' }">{{ $navItem['label'] }}</span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/kmx4nk

added the `x-cloak` attribute so the mobile menu is not shown until the scripts are loaded, which prevents a jump from happening on the mobile version of the site
 
## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
