### PR TITLE
chore: tooltip remove click trigger

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -3,7 +3,7 @@ import "tippy.js/dist/tippy.css";
 
 /** Enable tooltips for components with this data attribute, and global config options */
 tippy("[data-tippy-content]", {
-    trigger: "mouseenter click",
+    trigger: "mouseenter focus",
 });
 
 tippy("[data-tippy-hover]", {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes the click trigger on the tooltip that is keeping the tooltip over the screen until I click somewhere else

On mobile devices, it still shows the tooltip until I click somewhere else but personally don't felt that it's so annoying as the desktop version since is a common gesture but I let that open to your better opinion.

The alternative for mobile is to use the `touch` property that shows the tooltip while the user holds the tooltip trigger but if that is the case we actually have a `[data-tippy-hover]` (instead of `[data-tippy-content]`) attribute that already add that behavior so we can just replace the data attributes where we can that behavior or keep that as default

Just my two cents here: I tested the tooltips with the hold option on my cellphone and I didn't know I needed to hold the tooltip so first think it was broken because it was disappearing immediately I figured out that needed to hold it until I read the tippy docs so not sure if that really represents a UX improvement.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
