### PR TITLE
feat: update shadow and margin to the notifications dropdowns

### DIFF
--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -31,10 +31,10 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="origin-top-right absolute right-0 mt-2 rounded-md shadow-lg z-10 dropdown {{ $dropdownClasses ?? 'w-40' }}"
+        class="origin-top-right absolute right-0 mt-2 z-10 dropdown {{ $dropdownClasses ?? 'w-40' }}"
         @if ($height ?? false) data-height="{{ $height }}" @endif
     >
-        <div class="bg-white rounded-md shadow-lg dark:bg-theme-secondary-800 dark:text-theme-secondary-200" x-cloak>
+        <div class="{{ $dropdownContentClasses ??  'bg-white rounded-md shadow-lg dark:bg-theme-secondary-800 dark:text-theme-secondary-200' }}" x-cloak>
             <div class="py-1" @if($closeOnClick ?? true) @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif>
                 {{ $slot }}
             </div>

--- a/resources/views/navbar/notifications.blade.php
+++ b/resources/views/navbar/notifications.blade.php
@@ -1,5 +1,10 @@
 <div class="{{ $class ?? ''}}" @click="livewire.emit('markNotificationsAsSeen')">
-    <x-ark-dropdown wrapper-class="mx-1 md:relative" dropdown-classes="mt-4 {{ $dropdownClasses ?? '' }}" button-class="relative">
+    <x-ark-dropdown
+        wrapper-class="mx-1 md:relative"
+        dropdown-classes="mt-8 md:px-0 px-8 {{ $dropdownClasses ?? '' }}"
+        button-class="relative"
+        dropdown-content-classes="bg-white dark:bg-theme-secondary-800 dark:text-theme-secondary-200 rounded-xl shadow-2xl"
+    >
         <x-slot name="button">
             @svg('notification', 'h-5 w-5 transition-default text-theme-secondary-600 hover:text-theme-primary-700')
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- The notifications dropdown now have the same shadow and roundiness that is shown on the design
- Applied the margin used on the regular notifications  to the dropdown since (the margin on the design for the invitations is over the navbar)
- Some tweaks to the mobile version of both dropdowns

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
