### PR TITLE
chore: navbar button border alignment

### DIFF
--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -20,7 +20,7 @@
 
     <nav class="relative z-30 bg-white shadow-header-smooth dark:shadow-none dark:bg-theme-secondary-900">
         <div class="px-4 sm:px-6 lg:px-8 py-0.5">
-            <div class="flex relative justify-between h-20">
+            <div class="relative flex justify-between h-20">
                 @include('ark::navbar.logo')
 
                 @isset($middle)
@@ -28,7 +28,7 @@
                 @endisset
 
                 <div class="flex justify-end">
-                    <div class="flex flex-1 justify-end items-center sm:items-stretch sm:justify-between">
+                    <div class="flex items-center justify-end flex-1 sm:items-stretch sm:justify-between">
                         @isset($desktop)
                             {{ $desktop }}
                         @else
@@ -36,7 +36,7 @@
                         @endisset
                     </div>
 
-                    <div class="flex inset-y-0 right-0 items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
+                    <div class="inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
                         @include('ark::navbar.hamburger')
 
                         @isset($content)

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -20,7 +20,7 @@
 
     <nav class="relative z-30 bg-white shadow-header-smooth dark:shadow-none dark:bg-theme-secondary-900">
         <div class="px-4 sm:px-6 lg:px-8 py-0.5">
-            <div class="relative flex justify-between h-20">
+            <div class="flex relative justify-between h-20">
                 @include('ark::navbar.logo')
 
                 @isset($middle)
@@ -28,7 +28,7 @@
                 @endisset
 
                 <div class="flex justify-end">
-                    <div class="flex items-center justify-end flex-1 sm:items-stretch sm:justify-between">
+                    <div class="flex flex-1 justify-end items-center sm:items-stretch sm:justify-between">
                         @isset($desktop)
                             {{ $desktop }}
                         @else
@@ -36,7 +36,7 @@
                         @endisset
                     </div>
 
-                    <div class="inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
+                    <div class="flex inset-y-0 right-0 items-center pr-2 sm:static sm:inset-auto sm:ml-4 sm:pr-0">
                         @include('ark::navbar.hamburger')
 
                         @isset($content)

--- a/resources/views/navbar/items/desktop.blade.php
+++ b/resources/views/navbar/items/desktop.blade.php
@@ -36,7 +36,7 @@
                             </div>
                         @endforeach
                     </div>
-                    <div class="flex flex-col flex-shrink-0 pl-8 pr-8 w-128">
+                    <div class="flex flex-col flex-shrink-0 pr-8 pl-8 w-128">
                         <img class="w-full" :src="selectedChild ? selectedChild.image : '{{ $navItem['image'] }}'" />
 
                         <template x-if="selectedChild">
@@ -65,5 +65,5 @@
         @endisset
     @endforeach
 
-    <span class="h-5 border-r ml-7 border-theme-secondary-300 dark:border-theme-secondary-800"></span>
+    <span class="ml-7 h-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
 </div>

--- a/resources/views/navbar/items/desktop.blade.php
+++ b/resources/views/navbar/items/desktop.blade.php
@@ -18,7 +18,7 @@
         @isset($navItem['children'])
             <a
                 href="#"
-                class="relative inline-flex justify-center items-center px-1 pt-1 font-semibold leading-5 border-b-2 border-transparent text-theme-secondary-700 hover:text-theme-secondary-800 hover:border-theme-secondary-300 focus:outline-none transition duration-150 ease-in-out h-full dark:text-theme-secondary-500 dark:hover:text-theme-secondary-400
+                class="-mb-1 relative inline-flex justify-center items-center px-1 pt-1 font-semibold leading-5 border-b-2 border-transparent text-theme-secondary-700 hover:text-theme-secondary-800 hover:border-theme-secondary-300 focus:outline-none transition duration-150 ease-in-out h-full dark:text-theme-secondary-500 dark:hover:text-theme-secondary-400
                     @if(!$loop->first) ml-8 @endif"
                 @click="openDropdown = openDropdown === '{{ $navItem['label'] }}' ? null : '{{ $navItem['label'] }}'"
                 dusk='navbar-{{ Str::slug($navItem['label']) }}'
@@ -36,7 +36,7 @@
                             </div>
                         @endforeach
                     </div>
-                    <div class="flex flex-col flex-shrink-0 pr-8 pl-8 w-128">
+                    <div class="flex flex-col flex-shrink-0 pl-8 pr-8 w-128">
                         <img class="w-full" :src="selectedChild ? selectedChild.image : '{{ $navItem['image'] }}'" />
 
                         <template x-if="selectedChild">
@@ -49,7 +49,7 @@
         @else
             <a
                 href="{{ route($navItem['route'], $navItem['params'] ?? []) }}"
-                class="inline-flex items-center px-1 pt-1 font-semibold leading-5 border-b-2
+                class="inline-flex items-center px-1 pt-1 font-semibold leading-5 border-b-2 -mb-1
                     focus:outline-none transition duration-150 ease-in-out h-full
                     @if(optional(Route::current())->getName() === $navItem['route'])
                         border-theme-primary-600 text-theme-secondary-900 dark:text-theme-secondary-400
@@ -65,5 +65,5 @@
         @endisset
     @endforeach
 
-    <span class="ml-7 h-5 border-r border-theme-secondary-300 dark:border-theme-secondary-800"></span>
+    <span class="h-5 border-r ml-7 border-theme-secondary-300 dark:border-theme-secondary-800"></span>
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a negative margin to the button to compensate the navbar padding, since they have a border below that add some space below still looks centered

![image](https://user-images.githubusercontent.com/17262776/106314175-40983a00-6261-11eb-872e-8f97de221813.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
