### PR TITLE
refactor: make modals full screen on md screens and smaller

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -207,6 +207,10 @@
     .modal-content {
         max-width: 100% !important;
     }
+
+    .modal-content-wrapper {
+        max-width: 100% !important;
+    }
 }
 
 @screen md {

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -220,17 +220,17 @@
 }
 
 .modal-close {
-    @apply absolute top-0 right-0 w-10 h-10 mt-4 mr-4 rounded text-theme-secondary-700 bg-theme-secondary-100 transition-default;
+    @apply absolute top-0 right-0 w-10 h-10 mt-4 mr-4 rounded text-theme-secondary-900 bg-theme-info-100 transition-default;
 }
 .dark .modal-close {
     @apply bg-theme-secondary-800 text-theme-secondary-600;
 }
 
 .modal-close:hover {
-    @apply shadow-lg bg-theme-secondary-300;
+    @apply shadow-lg bg-theme-info-300;
 }
 .dark .modal-close:hover {
-    @apply bg-theme-secondary-700 text-theme-secondary-500;
+    @apply bg-theme-secondary-700 text-theme-secondary-400;
 }
 
 @screen lg {

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -199,8 +199,22 @@
 
 /** Modal **/
 .modal-content {
-    @apply relative mx-auto bg-white rounded-lg shadow-2xl;
+    @apply relative bg-white;
 }
+
+@media screen and (max-width: 767px) {
+    /* Needed for full-screen modals */
+    .modal-content {
+        max-width: 100% !important;
+    }
+}
+
+@screen md {
+    .modal-content {
+        @apply mx-auto rounded-lg shadow-2xl;
+    }
+}
+
 .dark .modal-content {
     @apply bg-theme-secondary-900;
 }

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -20,16 +20,16 @@
     x-data="Modal.livewire({{ $xData }})"
     x-init="init"
     @if(!$closeButtonOnly && $wireClose)
-    wire:click.self="{{ $wireClose }}"
+        wire:click.self="{{ $wireClose }}"
     @endif
-    class="flex overflow-y-auto fixed inset-0 z-50 py-10 px-8"
+    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
     @if(!$closeButtonOnly && $escToClose)
-    wire:keydown.escape="{{ $wireClose }}"
-    tabindex="0"
+        wire:keydown.escape="{{ $wireClose }}"
+        tabindex="0"
     @endif
 >
     <div
-        class="m-auto w-full {{ $class }}"
+        class="md:m-auto w-full {{ $class }}"
         @if($style) style="{{ $style }}" @endif
     >
         <div class="modal-content dropdown-scrolling {{ $widthClass }}">

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -29,7 +29,7 @@
     @endif
 >
     <div
-        class="md:m-auto w-full {{ $class }}"
+        class="modal-content-wrapper md:m-auto w-full {{ $class }} {{ $widthClass }}"
         @if($style) style="{{ $style }}" @endif
     >
         <div class="modal-content dropdown-scrolling {{ $widthClass }}">

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -39,7 +39,7 @@
                         class="modal-close"
                         @if($wireClose ?? false) wire:click="{{ $wireClose }}" @endif
                     >
-                        @svg('close', 'w-4 h-4 m-auto')
+                        @svg('close', 'w-5 h-5 m-auto')
                     </button>
                 @endif
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Makes modals take full width on smaller screens. If you did not use the modals properly regarding widths (in other words you didn't set it through the `widthClass` property) you need to update the modals to use that one

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
