### PR TITLE
chore: ensure tags focus class is not purged

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -186,6 +186,7 @@
 }
 
 /* Tags */
+/* purgecss ignore */
 .tags-input-focus {
     @apply border-theme-primary-600;
     box-shadow: 0 0 0 1px var(--theme-color-primary-600);

--- a/resources/views/inputs/tags.blade.php
+++ b/resources/views/inputs/tags.blade.php
@@ -2,7 +2,7 @@
     'xData' => '{}',
     'name',
     'errors',
-    'tags',
+    'tags' => [],
     'maxTags' => null,
     'allowedTags' => [],
     'id' => null,
@@ -30,7 +30,7 @@
         @endunless
 
         <div class="input-wrapper">
-            <div wire:ignore x-ref="input" class="relative py-2 px-3 bg-white rounded border border-theme-secondary-400"></div>
+            <div wire:ignore x-ref="input" class="relative px-3 py-2 bg-white border rounded border-theme-secondary-400"></div>
 
             {{-- Hidden select used to emulate wire:model behaviour --}}
             <select

--- a/resources/views/inputs/tags.blade.php
+++ b/resources/views/inputs/tags.blade.php
@@ -30,7 +30,7 @@
         @endunless
 
         <div class="input-wrapper">
-            <div wire:ignore x-ref="input" class="relative px-3 py-2 bg-white border rounded border-theme-secondary-400"></div>
+            <div wire:ignore x-ref="input" class="relative py-2 px-3 bg-white rounded border border-theme-secondary-400"></div>
 
             {{-- Hidden select used to emulate wire:model behaviour --}}
             <select


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Currently, that class is only on the scripts so purgecss is removing it

Plus: the tags prop doesn't need to be required

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
