### PR TITLE
feat: markdown parser for fields edited with the basic wyswyg editor

### DIFF
--- a/resources/assets/js/markdown-editor/css/style.css
+++ b/resources/assets/js/markdown-editor/css/style.css
@@ -238,4 +238,10 @@
     @apply bg-none;
 }
 
+.ark-markdown-editor-basic .tui-md-heading {
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+}
+
 /* purgecss end ignore */

--- a/resources/views/inputs/markdown.blade.php
+++ b/resources/views/inputs/markdown.blade.php
@@ -41,7 +41,7 @@ $icons = [
 ]
 @endphp
 
-<div class="ark-markdown-editor {{ $class ?? '' }}">
+<div class="ark-markdown-editor ark-markdown-editor-{{ $toolbar }} {{ $class ?? '' }}">
     <div class="input-group">
         @unless ($hideLabel ?? false)
             <label for="{{ $id ?? $name }}" class="input-label @error($name) input-label--error @enderror">
@@ -57,7 +57,7 @@ $icons = [
                     {{ $xData }}
                 )"
                 x-init="init"
-                class="overflow-hidden bg-white rounded border-2 border-theme-secondary-200"
+                class="overflow-hidden bg-white border-2 rounded border-theme-secondary-200"
             >
                 <div x-show="showOverlay" class="fixed top-0 left-0 z-50 w-full h-full bg-black bg-opacity-75" style="display: none"></div>
                 <div>

--- a/resources/views/inputs/markdown.blade.php
+++ b/resources/views/inputs/markdown.blade.php
@@ -57,7 +57,7 @@ $icons = [
                     {{ $xData }}
                 )"
                 x-init="init"
-                class="overflow-hidden bg-white border-2 rounded border-theme-secondary-200"
+                class="overflow-hidden bg-white rounded border-2 border-theme-secondary-200"
             >
                 <div x-show="showOverlay" class="fixed top-0 left-0 z-50 w-full h-full bg-black bg-opacity-75" style="display: none"></div>
                 <div>

--- a/src/Support/MarkdownParser.php
+++ b/src/Support/MarkdownParser.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\UserInterface\Support;
+
+use League\CommonMark\MarkdownConverterInterface;
+
+final class MarkdownParser
+{
+    private MarkdownConverterInterface $markdownConverter;
+
+    public function __construct()
+    {
+        $this->markdownConverter = resolve(MarkdownConverterInterface::class);
+    }
+
+    public function getMarkdownCoverter(): MarkdownConverterInterface
+    {
+        return $this->markdownConverter;
+    }
+
+    public static function basic(string $text): string
+    {
+        $markdownConverter = new self;
+
+        $rawHTML = $markdownConverter->getMarkdownCoverter()->convertToHtml($text);
+
+        $rawHTMLWithTagsAsParagraphs = $markdownConverter->convertHeadersToParagraphs($rawHTML);
+
+        return $markdownConverter->stripUnalllowedTags($rawHTMLWithTagsAsParagraphs);
+    }
+
+    public static function full(string $text): string
+    {
+        return (new self)->getMarkdownCoverter()->convertToHtml($text);
+    }
+
+    private function convertHeadersToParagraphs(string $html): string
+    {
+        $regex = '/<(h1|h2|h3|h4|h5|h6)\b[^>]*>(.*?)<\/\1>/mis';
+
+        $rawHTMLWithTagsAsParagraphs = preg_replace($regex, '<p>$2</p>', $html);
+
+        return $this->removeHeaderAnchors($rawHTMLWithTagsAsParagraphs);
+    }
+
+    private function removeHeaderAnchors(string $html): string
+    {
+        return preg_replace('/<a.*?\>#<\/a>/', '', $html);
+    }
+
+    private function stripUnalllowedTags(string $html): string
+    {
+        return strip_tags(
+            $html,
+            ['a', 'p', 'br', 'ul', 'ol', 'li', 'strong', 'em']
+        );
+    }
+}

--- a/src/Support/MarkdownParser.php
+++ b/src/Support/MarkdownParser.php
@@ -22,13 +22,13 @@ final class MarkdownParser
 
     public static function basic(string $text): string
     {
-        $markdownConverter = new self;
+        $markdownParser = new self;
 
-        $rawHTML = $markdownConverter->getMarkdownCoverter()->convertToHtml($text);
+        $rawHTML = $markdownParser->getMarkdownCoverter()->convertToHtml($text);
 
-        $rawHTMLWithTagsAsParagraphs = $markdownConverter->convertHeadersToParagraphs($rawHTML);
+        $rawHTMLWithTagsAsParagraphs = $markdownParser->convertHeadersToParagraphs($rawHTML);
 
-        return $markdownConverter->stripUnalllowedTags($rawHTMLWithTagsAsParagraphs);
+        return $markdownParser->stripUnalllowedTags($rawHTMLWithTagsAsParagraphs);
     }
 
     public static function full(string $text): string

--- a/src/Support/MarkdownParser.php
+++ b/src/Support/MarkdownParser.php
@@ -24,11 +24,11 @@ final class MarkdownParser
     {
         $markdownParser = new self;
 
-        $rawHTML = $markdownParser->getMarkdownCoverter()->convertToHtml($text);
+        $text = $markdownParser->encodeMarkdownHeaders($text);
 
-        $rawHTMLWithTagsAsParagraphs = $markdownParser->convertHeadersToParagraphs($rawHTML);
+        $html = $markdownParser->getMarkdownCoverter()->convertToHtml($text);
 
-        return $markdownParser->stripUnalllowedTags($rawHTMLWithTagsAsParagraphs);
+        return $markdownParser->stripUnalllowedTags($html);
     }
 
     public static function full(string $text): string
@@ -36,18 +36,9 @@ final class MarkdownParser
         return (new self)->getMarkdownCoverter()->convertToHtml($text);
     }
 
-    private function convertHeadersToParagraphs(string $html): string
+    private function encodeMarkdownHeaders(string $text): string
     {
-        $regex = '/<(h1|h2|h3|h4|h5|h6)\b[^>]*>(.*?)<\/\1>/mis';
-
-        $rawHTMLWithTagsAsParagraphs = preg_replace($regex, '<p>$2</p>', $html);
-
-        return $this->removeHeaderAnchors($rawHTMLWithTagsAsParagraphs);
-    }
-
-    private function removeHeaderAnchors(string $html): string
-    {
-        return preg_replace('/<a.*?\>#<\/a>/', '', $html);
+        return str_replace('#', '&#35;', $text);
     }
 
     private function stripUnalllowedTags(string $html): string


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Removes all the tags that are not part of the basic wyswyg editor
- For the header it first encodes the `#` symbol so if the user tries to write a header will see exactly what it write
- In the case of the editor the best workaround I found is to disable the style of the headers when the toolbar is `basic`

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
