### PR TITLE
feat: add expandable component

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -356,3 +356,58 @@ You can also get an alert with more padding and large icon by specifying `large`
 | buttonClassExpanded | The class(es) applied to the trigger button when content is visible  | no | 'text-theme-secondary-400 hover:text-theme-primary-500' |
 | wrapperClass | The class(es) applied to the wrapper element | no | '' |
 | dropdownContentClasses | The class(es) applied to the content container | no | null |
+
+### Expandable
+Displays a defined number of items and hides the rest, showing a button to show/hide the hidden items.
+It's possible to add placeholders and define when to show/hide them via css.
+The remaining items counter is automatically generated and can be displayed by adding a helper css class (2 helpers available).
+- `counter-before` prepends the counter inside the element.
+  _E.g. if the remainig items are 3 `<span class="counter-before">+</span>` outputs `<span class="counter-before">3+</span>`_
+- `counter-after` appends the counter inside the element.
+  _E.g. if the remainig items are 3 `<span class="counter-after">+</span>` outputs `<span class="counter-after">+3</span>`_
+
+As optional, an increment counter is automatically generated too and can be displayed by adding a helper css class (2 helpers available).
+- `increment-before` prepends the increment inside the element.
+  _E.g. for the 3rd item `<span class="increment-before">.</span>` outputs `<span class="increment-before">3.</span>`_
+- `increment-after` appends the increment inside the element.
+  _E.g. for the 3rd item `<span class="increment-after">.</span>` outputs `<span class="increment-after">.3</span>`_
+
+> Remember to wrap the items in `<x-ark-expandable-item>...</x-ark-expandable-item>` component.
+
+```blade
+<x-ark-expandable total="12">
+    @foreach($items as $item)
+        <x-ark-expandable-item>
+            {{ $item }}
+        <x-ark-expandable-item />
+    @endforeach
+
+    <x-slot name="placeholder">
+        ...
+    </x-slot>
+
+    <x-slot name="collapsed">
+        <span>
+            <!-- this append the counter after the "+" symbol -->
+            <span class="counter-after">+</span>
+            <span>show more</span>
+        </span>
+    </x-slot>
+
+    <x-slot name="expanded">
+        <span>hide</span>
+    </x-slot>
+<x-ark-expandable />
+```
+
+| Parameter | Description | Required | Default Value |
+|---|---|---|---|
+| total | Total count of items in the collection | yes | |
+| triggerDusk | Specify a trigger name used by Dusk | no | '' |
+| triggerClass | The class(es) applied to the trigger element | no | '' |
+| collapsedClass | The class(es) applied to the collepsed element | no | '' |
+| expandedClass | The class(es) applied to the expanded element | no | '' |
+| collapsed | The collapsed element | no | null |
+| expanded | The expanded element | no | false |
+| placeholder | The placeholder element | no | false |
+| placeholderCount | Total copy of placeholder | no | 1 |

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ There are also default error pages you can use for your Laravel project
 - `<x-ark-checkbox>`
 - `<x-ark-clipboard>`
 - `<x-ark-dropdown>`
+- `<x-ark-expandable>`
 - `<x-ark-input>`
 - `<x-ark-navbar>`
 - `<x-ark-radio>`

--- a/resources/assets/css/_expandable.css
+++ b/resources/assets/css/_expandable.css
@@ -1,0 +1,29 @@
+ol[data-expandable] {
+    counter-reset: total var(--expandable-total-count, 0) inc;
+}
+
+[data-expandable] li {
+    counter-increment: total -1 inc +1;
+}
+
+[data-expandable].show-all > [data-item] {
+    display: inherit !important;
+}
+
+/* show increment value on visible items */
+[data-expandable] .increment-before::before {
+    content: counter(inc);
+}
+
+[data-expandable] .increment-after::after {
+    content: counter(inc);
+}
+
+/* show total collapsed items */
+[data-expandable] .counter-before::before {
+    content: counter(total);
+}
+
+[data-expandable] .counter-after::after {
+    content: counter(total);
+}

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -187,7 +187,10 @@ module.exports = {
                     /is-bound/,
                 ],
 
-                deep: [/tippy-/],
+                deep: [
+                    /tippy-/,
+                    /\[data-expandable\]/,
+                ],
             },
         },
     },

--- a/resources/views/expandable-item.blade.php
+++ b/resources/views/expandable-item.blade.php
@@ -1,0 +1,3 @@
+<li data-item {{ $attributes->except('class') }}>
+    {{ $slot }}
+</li>

--- a/resources/views/expandable.blade.php
+++ b/resources/views/expandable.blade.php
@@ -1,0 +1,42 @@
+@props([
+    'total',
+    'triggerDusk' => null,
+    'triggerClass' => '',
+    'collapsedClass' => '',
+    'expandedClass' => '',
+    'collapsed' => null,
+    'expanded' => null,
+    'placeholder' => null,
+    'placeholderCount' => 1,
+])
+
+<ol data-expandable
+    x-data="{ expanded: false }"
+    :class="{ 'show-all': expanded }"
+    style="--expandable-total-count: {{ $total }};"
+    {{ $attributes }}
+>
+    {{ $slot }}
+
+    @isset ($placeholder)
+        @for ($i = 0; $i < $placeholderCount; $i++)
+            <li data-placeholder wire:key="expandable-placeholder-{{ Str::random(6) }}">
+                {{ $placeholder }}
+            </li>
+        @endfor
+    @endisset
+
+    <button data-trigger
+        class="{{ $triggerClass }}"
+        @click="expanded = !expanded"
+        @isset($triggerDusk) dusk="{{ $triggerDusk }}" @endisset
+        x-cloak
+    >
+        <span data-collapsed class="{{ $collapsedClass }}" x-show="!expanded">
+            {{ $collapsed }}
+        </span>
+        <span data-expanded class="{{ $expandedClass }}" x-show="expanded">
+            {{ $expanded }}
+        </span>
+    </button>
+</ol>

--- a/src/UserInterfaceServiceProvider.php
+++ b/src/UserInterfaceServiceProvider.php
@@ -2,14 +2,14 @@
 
 namespace ARKEcosystem\UserInterface;
 
+use ARKEcosystem\UserInterface\Components\FlashMessage;
+use ARKEcosystem\UserInterface\Components\Toast;
+use ARKEcosystem\UserInterface\Http\Controllers\WysiwygControlller;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Spatie\Flash\Flash;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\ServiceProvider;
-use ARKEcosystem\UserInterface\Components\Toast;
-use ARKEcosystem\UserInterface\Components\FlashMessage;
-use ARKEcosystem\UserInterface\Http\Controllers\WysiwygControlller;
-use Illuminate\Support\Facades\Route;
 
 class UserInterfaceServiceProvider extends ServiceProvider
 {
@@ -61,7 +61,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register routes
+     * Register routes.
      *
      * @return void
      */
@@ -91,7 +91,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
         ], 'pagination');
 
         $this->publishes([
-            __DIR__.'/../resources/assets/js/markdown-editor' => resource_path('js/vendor/ark/markdown-editor')
+            __DIR__.'/../resources/assets/js/markdown-editor' => resource_path('js/vendor/ark/markdown-editor'),
         ], 'wysiwyg');
 
         $this->publishes([
@@ -131,7 +131,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../resources/assets/js/prism-line-numbers.js' => resource_path('js/vendor/ark/prism-line-numbers.js'),
-            __DIR__.'/../resources/assets/js/prism.js' => resource_path('js/vendor/ark/prism.js'),
+            __DIR__.'/../resources/assets/js/prism.js'              => resource_path('js/vendor/ark/prism.js'),
         ], 'prism');
 
         $this->publishes([
@@ -147,7 +147,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
         ], 'highlightjs');
 
         $this->publishes([
-            __DIR__ . '/../resources/assets/js/file-download.js' => resource_path('js/vendor/ark/file-download.js'),
+            __DIR__.'/../resources/assets/js/file-download.js' => resource_path('js/vendor/ark/file-download.js'),
         ], 'file-download');
     }
 
@@ -206,6 +206,8 @@ class UserInterfaceServiceProvider extends ServiceProvider
         Blade::component('ark::details-box', 'ark-details-box');
         Blade::component('ark::details-box-mobile', 'ark-details-box-mobile');
         Blade::component('ark::dropdown', 'ark-dropdown');
+        Blade::component('ark::expandable', 'ark-expandable');
+        Blade::component('ark::expandable-item', 'ark-expandable-item');
         Blade::component('ark::external-link', 'ark-external-link');
         Blade::component('ark::flash', 'ark-flash');
         Blade::component('ark::footer-bar-desktop', 'ark-footer-bar-desktop');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
I've created this reusable component to display a defined number of items and hide the rest, showing a button to show/hide the hidden items. It's fully css customizable with the possibility to add placeholders too.

Under the hood, it automatically generates the `remaining items count` using css functions [`counter()`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter()), [`counter-reset()`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset), [`counter-increment()`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment) all with cross-browser full support. This approach is faster than javascript because doesn't need any scripts to work and avoids increasing the page-load.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
