### PR TITLE
refactor: added showMore slot for the expandable component

### DIFF
--- a/resources/views/expandable.blade.php
+++ b/resources/views/expandable.blade.php
@@ -31,16 +31,21 @@
         {{ $showMore }}
     @endisset
 
-    <button data-trigger
-        class="{{ $triggerClass }}"
-        @click="expanded = !expanded"
-        @isset($triggerDusk) dusk="{{ $triggerDusk }}" @endisset
-    >
-        <span data-collapsed class="{{ $collapsedClass }}" x-show="!expanded">
-            {{ $collapsed }}
-        </span>
-        <span data-expanded class="{{ $expandedClass }}" x-show="expanded" x-cloak>
-            {{ $expanded }}
-        </span>
-    </button>
+    @empty($showMore)
+        <button
+            data-trigger class="{{ $triggerClass }}"
+            @click="expanded = !expanded"
+            @isset($triggerDusk)
+                dusk="{{ $triggerDusk }}"
+            @endisset
+        >
+            <span data-collapsed class="{{ $collapsedClass }}" x-show="!expanded">
+                {{ $collapsed }}
+            </span>
+
+            <span data-expanded class="{{ $expandedClass }}" x-show="expanded" x-cloak>
+                {{ $expanded }}
+            </span>
+        </button>
+    @endempty
 </ol>

--- a/resources/views/expandable.blade.php
+++ b/resources/views/expandable.blade.php
@@ -8,6 +8,7 @@
     'expanded' => null,
     'placeholder' => null,
     'placeholderCount' => 1,
+    'showMore' => false,
 ])
 
 <ol data-expandable
@@ -24,6 +25,10 @@
                 {{ $placeholder }}
             </li>
         @endfor
+    @endisset
+
+    @isset($showMore)
+        {{ $showMore }}
     @endisset
 
     <button data-trigger

--- a/resources/views/expandable.blade.php
+++ b/resources/views/expandable.blade.php
@@ -8,7 +8,7 @@
     'expanded' => null,
     'placeholder' => null,
     'placeholderCount' => 1,
-    'showMore' => false,
+    'showMore' => null,
 ])
 
 <ol data-expandable


### PR DESCRIPTION
## Summary

Add a `showMore` slot on the component, which is useful for situations where we don't want to expand/collapse the button when clicking on it.

## Checklist

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged