### PR TITLE
feat: initialize tooltips when a livewire component is updated

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -25,3 +25,19 @@ window.initClipboard = () => {
         },
     });
 };
+
+if (typeof Livewire !== 'undefined') {
+    Livewire.hook('message.processed', (message, component) => {
+        tippy(component.el.querySelectorAll('[data-tippy-content]'), {
+            trigger: "mouseenter focus",
+            duration: 0,
+        });
+
+        tippy(component.el.querySelectorAll('[data-tippy-hover]'), {
+            touch: "hold",
+            trigger: "mouseenter",
+            content: (reference) => reference.dataset.tippyHover,
+            duration: 0,
+        });
+    });
+}

--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -26,14 +26,14 @@ window.initClipboard = () => {
     });
 };
 
-if (typeof Livewire !== 'undefined') {
-    Livewire.hook('message.processed', (message, component) => {
-        tippy(component.el.querySelectorAll('[data-tippy-content]'), {
+if (typeof Livewire !== "undefined") {
+    Livewire.hook("message.processed", (message, component) => {
+        tippy(component.el.querySelectorAll("[data-tippy-content]"), {
             trigger: "mouseenter focus",
             duration: 0,
         });
 
-        tippy(component.el.querySelectorAll('[data-tippy-hover]'), {
+        tippy(component.el.querySelectorAll("[data-tippy-hover]"), {
             touch: "hold",
             trigger: "mouseenter",
             content: (reference) => reference.dataset.tippyHover,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Uses the `message.processed` event  to detect changes on the livewire component and activate the new tooltips that can potentially appear
 
## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
