### PR TITLE
feat: add button-tag css class

### DIFF
--- a/resources/assets/css/_buttons.css
+++ b/resources/assets/css/_buttons.css
@@ -15,6 +15,15 @@
     @apply py-0.5 px-3 !important;
 }
 
+.button-outline {
+    @apply button-generic border-2 border-theme-primary-100 text-theme-primary-600;
+}
+
+.button-tag-outline {
+    @apply button-outline;
+    @apply py-0.5 px-3 !important;
+}
+
 .button-primary:disabled,
 .button-secondary:disabled,
 .button-cancel:disabled,
@@ -25,6 +34,13 @@ a.disabled {
     @apply shadow-none cursor-not-allowed pointer-events-none bg-theme-secondary-200 text-theme-secondary-400;
 }
 
+.button-outline:disabled,
+.button-outline.button-disabled,
+.button-tag-outline:disabled,
+.button-tag-outline.button-disabled {
+    @apply border-theme-secondary-200 text-theme-secondary-400 shadow-none cursor-not-allowed pointer-events-none;
+}
+
 .dark .button-primary:disabled,
 .dark .button-secondary:disabled,
 .dark .button-cancel:disabled,
@@ -33,6 +49,13 @@ a.disabled {
 .dark .button-disabled,
 .dark a.disabled {
     @apply bg-theme-secondary-800 text-theme-secondary-700;
+}
+
+.dark .button-outline:disabled,
+.dark .button-outline.button-disabled,
+.dark .button-tag-outline:disabled,
+.dark .button-tag-outline.button-disabled {
+    @apply border-theme-secondary-800 text-theme-secondary-700;
 }
 
 .button-secondary {
@@ -71,17 +94,33 @@ a.disabled {
     @apply bg-theme-secondary-800 text-theme-secondary-200;
 }
 
+.dark .button-outline,
+.dark .button-tag-outline {
+    @apply border-theme-secondary-800 text-theme-secondary-200;
+}
+
 .button-icon:hover,
 .button-secondary:hover,
 .button-icon-rounded:hover,
 .button-tag:hover {
     @apply text-white bg-theme-primary-700 shadow-button-secondary;
 }
+
+.button-outline:hover,
+.button-tag-outline:hover {
+    @apply text-white bg-theme-primary-700 border-transparent shadow-button-secondary;
+}
+
 .dark .button-icon:hover,
 .dark .button-icon-rounded:hover,
 .dark .button-secondary:hover,
 .dark .button-tag:hover {
     @apply bg-theme-primary-700 text-theme-secondary-200;
+}
+
+.dark .button-outline:hover,
+.dark .button-tag-outline:hover {
+    @apply border-theme-primary-700 text-theme-secondary-200;
 }
 
 .button-icon-primary:hover {

--- a/resources/assets/css/_buttons.css
+++ b/resources/assets/css/_buttons.css
@@ -10,6 +10,11 @@
     @apply bg-theme-primary-700 shadow-button-primary;
 }
 
+.button-tag {
+    @apply button-secondary;
+    @apply py-0.5 px-3 !important;
+}
+
 .button-primary:disabled,
 .button-secondary:disabled,
 .button-cancel:disabled,
@@ -61,18 +66,21 @@ a.disabled {
 }
 .dark .button-icon,
 .dark .button-icon-rounded,
-.dark .button-secondary {
+.dark .button-secondary,
+.dark .button-tag {
     @apply bg-theme-secondary-800 text-theme-secondary-200;
 }
 
 .button-icon:hover,
 .button-secondary:hover,
-.button-icon-rounded:hover {
+.button-icon-rounded:hover,
+.button-tag:hover {
     @apply text-white bg-theme-primary-700 shadow-button-secondary;
 }
 .dark .button-icon:hover,
 .dark .button-icon-rounded:hover,
-.dark .button-secondary:hover {
+.dark .button-secondary:hover,
+.dark .button-tag:hover {
     @apply bg-theme-primary-700 text-theme-secondary-200;
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Since tags are widely used, I thought was great having a css class to style them around the entire ecosystem.
I've also added the outline version.

| Button | Normal state | Hover state | Disabled state |
|---|---|---|---|
| .button-tag | x | x | x |
| .button-outline | x | x | x |
| .button-tag-outline | x | x | x |
| .dark .button-tag | x | x | x |
| .dark .button-outline | x | x | x |
| .dark .button-tag-outline | x | x | x |

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
