### PR TITLE
fix: js-modal fixed position to prevent autoscrolling

### DIFF
--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -14,7 +14,6 @@
 
 <div
     x-ref="modal"
-    x-show="shown"
     data-modal
     x-cloak
     @if($init)
@@ -25,10 +24,12 @@
     @keydown.escape="hide"
     tabindex="0"
     @endif
+    x-show="shown"
+    class="fixed inset-0 z-50 "
 >
-    <div class="fixed inset-0 z-40 opacity-75 bg-theme-secondary-900 dark:bg-theme-secondary-800 dark:opacity-50"></div>
+    <div class="fixed inset-0 opacity-75 bg-theme-secondary-900 dark:bg-theme-secondary-800 dark:opacity-50"></div>
 
-    <div class="flex overflow-y-auto fixed inset-0 z-50 py-10 px-5">
+    <div class="fixed inset-0 flex px-5 py-10 overflow-y-auto">
         <div
             class="m-auto w-full {{ $class }}"
             @if(!$closeButtonOnly)

--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -29,7 +29,7 @@
 >
     <div class="fixed inset-0 opacity-75 bg-theme-secondary-900 dark:bg-theme-secondary-800 dark:opacity-50"></div>
 
-    <div class="fixed inset-0 flex px-5 py-10 overflow-y-auto">
+    <div class="flex overflow-y-auto fixed inset-0 py-10 px-5">
         <div
             class="m-auto w-full {{ $class }}"
             @if(!$closeButtonOnly)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the classes for the js-modal to prevent scrolling when the modal is on the footer of the page (before </body>) like it works here https://github.com/ArkEcosystem/marketsquare.io/pull/1418

Currently, when the modal is opened, the page is scrolling to the bottom of the page. This PR solves that
 
## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
