### PR TITLE
refactor: keep pointer events on disabled tiles

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -4,7 +4,7 @@
 }
 
 .dropdown-entry {
-    @apply block py-4 px-6 w-full font-semibold leading-5 text-left transition duration-150 ease-in-out cursor-pointer text-theme-secondary-800;
+    @apply block w-full px-6 py-4 font-semibold leading-5 text-left transition duration-150 ease-in-out cursor-pointer text-theme-secondary-800;
 }
 
 .dropdown-entry:focus {
@@ -398,27 +398,30 @@
 }
 
 .tile-link {
-    @apply relative rounded-lg cursor-pointer select-none bg-white h-30 transition-default;
+    @apply relative bg-white rounded-lg cursor-pointer select-none h-30 transition-default;
+}
+.tile-link:not(.tile-link-disabled) {
+    @apply cursor-pointer;
 }
 .tile-link:not(.tile-links-show-more) {
     @apply text-theme-secondary-900;
 }
-.tile-link:hover {
-    @apply shadow-lg text-theme-primary-700 border-transparent;
+.tile-link:not(.tile-link-disabled):hover {
+    @apply border-transparent shadow-lg text-theme-primary-700;
 }
 
 .tile-link-title-icon {
-    @apply flex flex-col justify-center items-center h-full font-semibold;
+    @apply flex flex-col items-center justify-center h-full font-semibold;
 }
 .tile-link-sm .tile-link-title-icon {
     @apply flex-row;
 }
 
 .tile-links-show-more {
-    @apply tile-link font-semibold text-center rounded bg-white text-theme-primary-600;
+    @apply font-semibold text-center bg-white rounded tile-link text-theme-primary-600;
 }
 .tile-links-show-more:hover {
-    @apply bg-theme-primary-700 text-white;
+    @apply text-white bg-theme-primary-700;
 }
 
 .tile-link-border {
@@ -445,7 +448,7 @@
 
     .tile-link-sm,
     .tile-link-md {
-        @apply h-13 text-base;
+        @apply text-base h-13;
     }
 }
 
@@ -465,15 +468,11 @@
 
 /* Disabled tiles */
 .disabled-tile {
-    @apply opacity-50 border-theme-secondary-300 bg-transparent pointer-events-none;
+    @apply bg-transparent opacity-50 pointer-events-none border-theme-secondary-300;
 }
 
 .tile-link-disabled:not(.tile-links-show-more) {
     @apply text-theme-secondary-500;
-}
-
-.tile-link-disabled {
-    @apply pointer-events-none;
 }
 
 .tile-link-disabled.tile-link-border {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Because class for disabling the pointer-events on disabled titles the tooltips applied to those are not working, this PR solves the problem while keeping the same disabled behaviour.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
