### PR TITLE
fix: make wire:key of the delete button unique

### DIFF
--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -23,12 +23,12 @@
         <input
             id="image-collection-upload-{{ $id }}"
             type="file"
-            class="absolute top-0 hidden block opacity-0 cursor-pointer"
+            class="block hidden absolute top-0 opacity-0 cursor-pointer"
             wire:model="temporaryImage"
             accept="image/jpg,image/jpeg,image/bmp,image/png"
         />
 
-        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -46,7 +46,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -56,7 +56,7 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
                     ></div>
 
                     <div

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -23,12 +23,12 @@
         <input
             id="image-collection-upload-{{ $id }}"
             type="file"
-            class="block hidden absolute top-0 opacity-0 cursor-pointer"
+            class="absolute top-0 hidden block opacity-0 cursor-pointer"
             wire:model="temporaryImage"
             accept="image/jpg,image/jpeg,image/bmp,image/png"
         />
 
-        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -46,7 +46,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -56,11 +56,11 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
                     ></div>
 
                     <div
-                        wire:key="delete-button"
+                        wire:key="delete-button-{{ $id }}"
                         class="absolute top-0 opacity-0 hover:opacity-100 transition-default w-full {{ $imageHeight }}"
                     >
                         <div class="pointer-events-none rounded-xl absolute top-0 opacity-70 border-6 border-theme-secondary-900 transition-default w-full {{ $imageHeight }}"></div>

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -33,7 +33,7 @@
                 <input
                     id="image-single-upload-{{ $id }}"
                     type="file"
-                    class="absolute top-0 hidden block opacity-0 cursor-pointer"
+                    class="block hidden absolute top-0 opacity-0 cursor-pointer"
                     wire:model="imageSingle"
                     accept="image/jpg,image/jpeg,image/bmp,image/png"
                 />
@@ -43,7 +43,7 @@
         @if (!$image && !$readonly)
             <div
                 wire:key="upload-button"
-                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
                 role="button"
             >
                 <div class="text-theme-primary-500">
@@ -69,7 +69,7 @@
                     @unless ($image) hidden @endunless"
 
             >
-                <div class="absolute top-0 w-full h-full pointer-events-none rounded-xl opacity-70 border-6 border-theme-secondary-900 transition-default"></div>
+                <div class="absolute top-0 w-full h-full rounded-xl opacity-70 pointer-events-none border-6 border-theme-secondary-900 transition-default"></div>
 
                 <div
                     class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
@@ -81,7 +81,7 @@
             </div>
 
             <div x-show="isUploading" x-cloak>
-                <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+                <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
             </div>
         @endunless
     </div>

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -33,7 +33,7 @@
                 <input
                     id="image-single-upload-{{ $id }}"
                     type="file"
-                    class="block hidden absolute top-0 opacity-0 cursor-pointer"
+                    class="absolute top-0 hidden block opacity-0 cursor-pointer"
                     wire:model="imageSingle"
                     accept="image/jpg,image/jpeg,image/bmp,image/png"
                 />
@@ -43,7 +43,7 @@
         @if (!$image && !$readonly)
             <div
                 wire:key="upload-button"
-                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
+                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
                 role="button"
             >
                 <div class="text-theme-primary-500">
@@ -64,12 +64,12 @@
 
         @unless($readonly)
             <div
-                wire:key="delete-button"
+                wire:key="delete-button-{{ $id }}"
                 class="rounded-xl absolute top-0 opacity-0 hover:opacity-100 transition-default w-full h-full
                     @unless ($image) hidden @endunless"
 
             >
-                <div class="absolute top-0 w-full h-full rounded-xl opacity-70 pointer-events-none border-6 border-theme-secondary-900 transition-default"></div>
+                <div class="absolute top-0 w-full h-full pointer-events-none rounded-xl opacity-70 border-6 border-theme-secondary-900 transition-default"></div>
 
                 <div
                     class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
@@ -81,7 +81,7 @@
             </div>
 
             <div x-show="isUploading" x-cloak>
-                <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+                <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
             </div>
         @endunless
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary


https://app.clickup.com/t/f3434j

The delete button of both components for uploading image has a wire:key with the same name, that is causing issues if both components are added on the same page like is described on the ticket.

To test use this version of the package on msq and try to follow the step described on the ticket:

1. Create a project
2. Add a Project Logo
3. Add a screenshot image
4. Save project
5. Edit Project
6. Try to Remove Project Logo image
7. Fails

Once this is merged the problem should be solved.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
