### PR TITLE
fix: dont allow more images than the limit / make the limit overridable

### DIFF
--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -26,5 +26,6 @@ return [
         'drag_drop_browse' => '<span class="hidden md:inline">Drag & Drop your files here or</span> <a @click="select()" class="link">Browse Files</a>',
         'delete_image'     => 'Delete Image',
         'requirements'     => '<span>Min size :width x :height. Max filesize :filesize.</span> <span>Max :quantity images</span>',
+        'requirements_no_max'     => '<span>Min size :width x :height. Max filesize :filesize.</span>',
     ],
 ];

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -26,6 +26,5 @@ return [
         'drag_drop_browse' => '<span class="hidden md:inline">Drag & Drop your files here or</span> <a @click="select()" class="link">Browse Files</a>',
         'delete_image'     => 'Delete Image',
         'requirements'     => '<span>Min size :width x :height. Max filesize :filesize.</span> <span>Max :quantity images</span>',
-        'requirements_no_max'     => '<span>Min size :width x :height. Max filesize :filesize.</span>',
     ],
 ];

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -28,7 +28,7 @@
             multiple
         />
 
-        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -46,7 +46,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -56,7 +56,7 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
                     ></div>
 
                     <div

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -28,7 +28,7 @@
             multiple
         />
 
-        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -54,7 +54,7 @@
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -64,7 +64,7 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
                     ></div>
 
                     <div

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -28,7 +28,7 @@
             multiple
         />
 
-        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -36,25 +36,17 @@
             <div class="font-semibold text-theme-secondary-900">{!! $uploadText !!}</div>
 
             <div class="flex flex-col space-y-1 text-xs font-semibold text-center sm:flex-row sm:space-y-0 sm:space-x-1 text-theme-secondary-500 chunk-header">
-                @if($this->getImageCollectionMaxQuantity() > 0)
-                    @lang('ui::forms.upload-image-collection.requirements', [
-                        'width'    => $minWidth,
-                        'height'   => $minHeight,
-                        'filesize' => $maxFilesize,
-                        'quantity' => $this->getImageCollectionMaxQuantity(),
-                    ])
-                @else
-                    @lang('ui::forms.upload-image-collection.requirements_no_max', [
-                        'width'    => $minWidth,
-                        'height'   => $minHeight,
-                        'filesize' => $maxFilesize
-                    ])
-                @endif
+                @lang('ui::forms.upload-image-collection.requirements', [
+                    'width'    => $minWidth,
+                    'height'   => $minHeight,
+                    'filesize' => $maxFilesize,
+                    'quantity' => $this->getImageCollectionMaxQuantity(),
+                ])
             </div>
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -64,7 +56,7 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
                     ></div>
 
                     <div

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -8,7 +8,6 @@
     'minWidth'           => 148,
     'minHeight'          => 148,
     'maxFilesize'        => '2MB',
-    'maxQuantity'        => 8,
     'uploadErrorMessage' => null,
 ])
 
@@ -29,7 +28,7 @@
             multiple
         />
 
-        <div class="flex flex-col justify-center items-center space-y-2 w-full h-full rounded-xl bg-theme-primary-50">
+        <div class="flex flex-col items-center justify-center w-full h-full space-y-2 rounded-xl bg-theme-primary-50">
             <div class="text-theme-primary-500">
                 <x-ark-icon name="upload-cloud" size="lg" />
             </div>
@@ -37,17 +36,25 @@
             <div class="font-semibold text-theme-secondary-900">{!! $uploadText !!}</div>
 
             <div class="flex flex-col space-y-1 text-xs font-semibold text-center sm:flex-row sm:space-y-0 sm:space-x-1 text-theme-secondary-500 chunk-header">
-                @lang('ui::forms.upload-image-collection.requirements', [
-                    'width'    => $minWidth,
-                    'height'   => $minHeight,
-                    'filesize' => $maxFilesize,
-                    'quantity' => $maxQuantity,
-                ])
+                @if($this->getImageCollectionMaxQuantity() > 0)
+                    @lang('ui::forms.upload-image-collection.requirements', [
+                        'width'    => $minWidth,
+                        'height'   => $minHeight,
+                        'filesize' => $maxFilesize,
+                        'quantity' => $this->getImageCollectionMaxQuantity(),
+                    ])
+                @else
+                    @lang('ui::forms.upload-image-collection.requirements_no_max', [
+                        'width'    => $minWidth,
+                        'height'   => $minHeight,
+                        'filesize' => $maxFilesize
+                    ])
+                @endif
             </div>
         </div>
 
         <div x-show="isUploading" x-cloak>
-            <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions" />
+            <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions" />
         </div>
     </div>
 
@@ -57,7 +64,7 @@
                 <div class="relative {{ $imageHeight }}">
                     <div
                         style="background-image: url('{{ $image['url'] }}')"
-                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover rounded-xl border border-theme-secondary-300"
+                        class="inline-block w-full h-full bg-center bg-no-repeat bg-cover border rounded-xl border-theme-secondary-300"
                     ></div>
 
                     <div

--- a/src/Components/UploadImageCollection.php
+++ b/src/Components/UploadImageCollection.php
@@ -19,7 +19,7 @@ trait UploadImageCollection
 
     public function getImageCollectionMaxQuantity(): int
     {
-        return 0;
+        return 8;
     }
 
     public function updatedTemporaryImages()
@@ -62,13 +62,9 @@ trait UploadImageCollection
     public function imageCollectionValidators(): array
     {
         return [
-            'imageCollection' => ['array', $this->getImageCollectionMaxQuantity() > 0 ? ('max:' . $this->getImageCollectionMaxQuantity()) : ''], // max 8 entries as we validate before adding to array
+            'imageCollection' => ['array', 'max:' . $this->getImageCollectionMaxQuantity()],
             'temporaryImages'  => function ($attribute, $value, $fail) {
                 $max = $this->getImageCollectionMaxQuantity();
-
-                if ($max <= 0) {
-                    return;
-                }
 
                 if (count($value) + count($this->imageCollection) > $max) {
                     $fail(trans('validation.max.array', [

--- a/src/Components/UploadImageCollection.php
+++ b/src/Components/UploadImageCollection.php
@@ -17,9 +17,16 @@ trait UploadImageCollection
 
     public $temporaryImages = [];
 
+    public function getImageCollectionMaxQuantity(): int
+    {
+        return 0;
+    }
+
     public function updatedTemporaryImages()
     {
-        $this->validateImageCollection();
+        if (!$this->validateImageCollection()) {
+            return;
+        }
 
         $this->imageCollection = array_merge($this->imageCollection, array_map(fn($image) => [
             'image' => $image,
@@ -32,7 +39,7 @@ trait UploadImageCollection
         $this->imageCollection = collect($this->imageCollection)->forget($index)->toArray();
     }
 
-    public function validateImageCollection(): void
+    public function validateImageCollection(): bool
     {
         $validator = Validator::make([
             'imageCollection' => $this->imageCollection,
@@ -45,14 +52,35 @@ trait UploadImageCollection
             }
 
             $validator->validate();
+
+            return false;
         }
+
+        return true;
     }
 
     public function imageCollectionValidators(): array
     {
         return [
-            'imageCollection' => ['array', 'max:7'], // max 8 entries as we validate before adding to array
-            'temporaryImages.*'  => ['mimes:jpeg,png,bmp,jpg', 'max:2048'],
+            'imageCollection' => ['array', $this->getImageCollectionMaxQuantity() > 0 ? ('max:' . $this->getImageCollectionMaxQuantity()) : ''], // max 8 entries as we validate before adding to array
+            'temporaryImages'  => function ($attribute, $value, $fail) {
+                $max = $this->getImageCollectionMaxQuantity();
+
+                if ($max <= 0) {
+                    return;
+                }
+
+                if (count($value) + count($this->imageCollection) > $max) {
+                    $fail(trans('validation.max.array', [
+                        'max' => $max,
+                        'attribute' => 'image collection',
+                    ]));
+                }
+            },
+            'temporaryImages.*'  => [
+                'mimes:jpeg,png,bmp,jpg',
+                'max:2048',
+            ],
         ];
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Prevent that the user upload more images than the limit (currently can bypass the limit if upload multiple ones at once)
- The max qty of images is now inside a method in the trait that can be overridden in case we need a different limit,
- By default, the component will not have limit

### How to test

Once merged upgrade this library on msq and try to upload more than 8 images at once, you should see a warning

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
