### PR TITLE
feat: event listener to remove temporary tag from input

### DIFF
--- a/resources/assets/js/tags.js
+++ b/resources/assets/js/tags.js
@@ -73,7 +73,9 @@ const Tags = (
 
             this.$nextTick(() => {
                 if (select) {
-                    const options = Array.from(select.querySelectorAll("option"));
+                    const options = Array.from(
+                        select.querySelectorAll("option")
+                    );
                     options.forEach((o) => {
                         o.selected = true;
                     });

--- a/resources/assets/js/tags.js
+++ b/resources/assets/js/tags.js
@@ -62,16 +62,23 @@ const Tags = (
             });
         }
 
+        Livewire.on("selectedTagRemoved", (tag) => {
+            taggle.remove(tag);
+        });
+
         this.$watch("availableTags", (availableTags) => {
             const { select } = this.$refs;
 
             this.setTaggleTags(taggle, availableTags);
+
             this.$nextTick(() => {
-                const options = Array.from(select.querySelectorAll("option"));
-                options.forEach((o) => {
-                    o.selected = true;
-                });
-                select.dispatchEvent(new Event("change"));
+                if (select) {
+                    const options = Array.from(select.querySelectorAll("option"));
+                    options.forEach((o) => {
+                        o.selected = true;
+                    });
+                    select.dispatchEvent(new Event("change"));
+                }
             });
         });
     },


### PR DESCRIPTION
## Summary

New `selectedTagRemoved` event listener allowing us to remove a temporary tag from the `taggle` input on it's deletion.

## Checklist

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged