### PR TITLE
fix: set the initial value of the user tagger

### DIFF
--- a/resources/assets/js/user-tagger.js
+++ b/resources/assets/js/user-tagger.js
@@ -107,10 +107,12 @@ window.UserTagger = (endpoint, contextUsers, maxLength = null) => {
             }
 
             input.value = value;
+
             var event = new Event("input", {
                 bubbles: true,
                 cancelable: true,
             });
+
             input.dispatchEvent(event);
         },
 
@@ -123,7 +125,10 @@ window.UserTagger = (endpoint, contextUsers, maxLength = null) => {
         },
 
         init() {
-            const { editor } = this.$refs;
+            const { input, editor } = this.$refs;
+
+            editor.innerHTML = input.value;
+            this.latestValue = input.value;
 
             tribute.attach(editor);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The user tagger is currently not initializing the initial value of the `wire:model` so when editing a value it doesn't works, this pR fixed the problem

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
