### PR TITLE
fix: remove vertical space on mobile for tile selection component

### DIFF
--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,6 +1,5 @@
 <div
-    class="flex relative flex-col"
-    x-bind:class="{@if ($mobileHidden) 'hidden sm:block': mobileHidden @endif}"
+    class="flex relative flex-col {{ $mobileHidden ? 'hidden sm:block' : '' }}"
 >
     @if($isDisabled && ! $option['checked'])
         <div data-tippy-content="{{ $disabledCheckboxTooltip }}" class="absolute inset-0"></div>

--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,4 +1,7 @@
-<div class="flex relative flex-col">
+<div
+    class="flex relative flex-col"
+    x-bind:class="{@if ($mobileHidden) 'hidden sm:block': mobileHidden @endif}"
+>
     @if($isDisabled && ! $option['checked'])
         <div data-tippy-content="{{ $disabledCheckboxTooltip }}" class="absolute inset-0"></div>
     @endif


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/fq7327
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
