### PR TITLE
fix: prevent the notification dropdown to be larger than screens

### DIFF
--- a/resources/views/secondary-menu.blade.php
+++ b/resources/views/secondary-menu.blade.php
@@ -1,9 +1,9 @@
-<div x-data="{ open: false }" @keydown.window.escape="open = false" @click.away="open = false" class="inline-block relative w-full text-left">
+<div x-data="{ open: false }" @keydown.window.escape="open = false" @click.away="open = false" class="relative inline-block w-full text-left">
     <div>
         <button
             @click="open = !open"
             type="button"
-            class="inline-flex relative justify-start items-center py-3 px-4 w-full rounded-lg border border-theme-secondary-200"
+            class="relative inline-flex items-center justify-start w-full px-4 py-3 border rounded-lg border-theme-secondary-200"
         >
             @svg('menu-open', 'h-4 w-4 text-theme-secondary-900 mr-3')
             <span class="font-semibold text-theme-secondary-900">{{ $title }}</span>
@@ -17,7 +17,7 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="absolute right-0 z-10 mt-2 w-full rounded-md shadow-lg origin-top"
+        class="absolute right-0 z-10 w-full max-w-full mt-2 origin-top rounded-md shadow-lg"
         x-cloak
     >
         <div class="w-full py-4 bg-white rounded-md shadow-lg {{ $navigationClass ?? '' }}">

--- a/resources/views/secondary-menu.blade.php
+++ b/resources/views/secondary-menu.blade.php
@@ -1,9 +1,9 @@
-<div x-data="{ open: false }" @keydown.window.escape="open = false" @click.away="open = false" class="relative inline-block w-full text-left">
+<div x-data="{ open: false }" @keydown.window.escape="open = false" @click.away="open = false" class="inline-block relative w-full text-left">
     <div>
         <button
             @click="open = !open"
             type="button"
-            class="relative inline-flex items-center justify-start w-full px-4 py-3 border rounded-lg border-theme-secondary-200"
+            class="inline-flex relative justify-start items-center py-3 px-4 w-full rounded-lg border border-theme-secondary-200"
         >
             @svg('menu-open', 'h-4 w-4 text-theme-secondary-900 mr-3')
             <span class="font-semibold text-theme-secondary-900">{{ $title }}</span>
@@ -17,7 +17,7 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="absolute right-0 z-10 w-full max-w-full mt-2 origin-top rounded-md shadow-lg"
+        class="absolute right-0 z-10 mt-2 w-full max-w-full rounded-md shadow-lg origin-top"
         x-cloak
     >
         <div class="w-full py-4 bg-white rounded-md shadow-lg {{ $navigationClass ?? '' }}">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to fixes for this ticket: https://app.clickup.com/t/g33fcj

Dependant on https://github.com/ArkEcosystem/laravel-hermes/pull/28

Due to a change in the styles for the notifications, dropdown is possible that the notifications dropdown grows over the screen with a large title, this PR prevents that

Test by following the instructions on the main PR https://github.com/ArkEcosystem/laravel-hermes/pull/28

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
