### PR TITLE
fix: disable tile selection while making requests

### DIFF
--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -5,6 +5,7 @@
         <div data-tippy-content="{{ $disabledCheckboxTooltip }}" class="absolute inset-0"></div>
     @endif
     <label
+        wire:loading.class="disabled-tile"
         wire:key="tile-selection-option-{{ $option['id'] }}"
         class="{{ $single ? 'tile-selection-single' : 'tile-selection-option' }} {{ $isDisabled && ! $option['checked'] ? 'disabled-tile' : '' }}"
         x-bind:class="{
@@ -37,6 +38,7 @@
                 @if($isDisabled && ! $option['checked'])
                     disabled
                 @endif
+                wire:loading.attr="disabled"
             />
         @endif
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g32f3z

Due to the async way livewire works the tile selection related to the platform selection when registering a project are not disabled until the model is saved so if the user clicks past it can select more options.

This PR disabled the files while making the request to prevent that

To test create a new project and try to select more that 5 platforms 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
