### PR TITLE
fix: remove selection tiles select all and use only wire:model

### DIFF
--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -11,9 +11,9 @@
         x-bind:class="{
             @if ($mobileHidden) 'hidden sm:block': mobileHidden, @endif
             @if ($single)
-                'tile-selection--checked': '{{ $option['id'] }}' === selectedOption }",
+                'tile-selection--checked': '{{ $option['id'] }}' === selectedOption,
             @else
-                'tile-selection--checked': options['{{ $option['id'] }}'].checked }",
+                'tile-selection--checked': {{ $option['checked'] ? 'true' : 'false' }},
             @endif
         }"
     >
@@ -33,8 +33,8 @@
                 name="{{ $option['id'] }}"
                 type="checkbox"
                 class="form-checkbox tile-selection-checkbox"
-                x-model="options['{{ $option['id'] }}'].checked"
                 wire:model="{{ $wireModel }}"
+                wire:key="{{ $option['id'] }}"
                 @if($isDisabled && ! $option['checked'])
                     disabled
                 @endif

--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -14,7 +14,6 @@
     'iconWrapper' => 'flex flex-col justify-center items-center md:space-y-2 h-full',
     'iconBreakpoints' => null,
     'optionTitleClass' => 'font-semibold',
-    'withoutSelectAll' => false,
     'selectionLimit' => null,
     'selectedOptionsCount' => null,
     'selectedOptionsTooltip' => null,
@@ -25,19 +24,8 @@
     wire:key="tile-selection-{{ $id }}"
     class="space-y-4 {{ $class }}"
     x-data="{
-        options: {{ json_encode(collect($options)->keyBy('id')) }},
         selectedOption: @if ($single) '{{ $this->{$model ?? $id} }}' @else null @endif,
-        allSelected: false,
         mobileHidden: true,
-        selectAll: function() {
-            let checkAllValue = true;
-            if (this.allSelected) {
-                checkAllValue = false;
-            }
-            for (const optionKey in this.options) {
-                this.options[optionKey].checked = checkAllValue;
-            }
-        }
     }"
 >
     <div class="{{ $wrapperClass }}">
@@ -56,20 +44,7 @@
                 </div>
             @endif
 
-            @unless ($hiddenOptions || $single === true || $withoutSelectAll)
-                <label class="tile-selection-select-all">
-                    <input
-                        type="checkbox"
-                        class="form-checkbox tile-selection-select-all-checkbox"
-                        x-on:click="selectAll"
-                        x-model="allSelected"
-                    />
-
-                    <div>@lang('ui::general.select-all')</div>
-                </label>
-            @endunless
-
-            @if($withoutSelectAll && $selectionLimit)
+            @if($selectionLimit)
                 <label class="tile-selection-select-all">
                     <div data-tippy-content="{{ $selectedOptionsTooltip }}">{{ $selectedOptionsCount }} / {{ $selectionLimit }}</div>
                 </label>
@@ -83,7 +58,7 @@
                         'option' => $option,
                         'wireModel' => $single ? ($model ?? $id) : ($model ?? $id).'.'.$option['id'].'.checked',
                         'mobileHidden' => $loop->index >= ($mobileShowRows * 2),
-                        'isDisabled' => $withoutSelectAll ? ($selectedOptionsCount >= $selectionLimit) : false,
+                        'isDisabled' => $selectionLimit ? ($selectedOptionsCount >= $selectionLimit) : false,
                         'disabledCheckboxTooltip' => $disabledCheckboxTooltip,
                     ])
                 @endforeach


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Removes the alpine x-model from the tile-selection that was having issues related to syncing values between the wire:model and the x-model
- Removes the select all that is currently not used, if is used in the future we can re-implement it following a different approach since the current one was not syncing the wire:model also

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
