### PR TITLE
fix: broken mobile hidden behaviour on tiles

### DIFF
--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,5 +1,8 @@
 <div
-    class="flex relative flex-col {{ $mobileHidden ? 'hidden sm:block' : '' }}"
+    class="relative flex flex-col"
+    x-bind:class="{
+        @if ($mobileHidden) 'hidden sm:flex': mobileHidden, @endif
+    }"
 >
     @if($isDisabled && ! $option['checked'])
         <div data-tippy-content="{{ $disabledCheckboxTooltip }}" class="absolute inset-0"></div>
@@ -8,7 +11,6 @@
         wire:key="tile-selection-option-{{ $option['id'] }}"
         class="{{ $single ? 'tile-selection-single' : 'tile-selection-option' }} {{ $isDisabled && ! $option['checked'] ? 'disabled-tile' : '' }}"
         x-bind:class="{
-            @if ($mobileHidden) 'hidden sm:block': mobileHidden, @endif
             @if ($single)
                 'tile-selection--checked': '{{ $option['id'] }}' === selectedOption }",
             @else

--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="relative flex flex-col"
+    class="flex relative flex-col"
     x-bind:class="{
         @if ($mobileHidden) 'hidden sm:flex': mobileHidden, @endif
     }"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g523f8

As explained on the ticket currently the "view more" button is not working on mobile for showing the hidden tiles.

Testing by opening the create registration form on mobile and using the view more button

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
