### PR TITLE
fix: use mb_strlen to correctly count unicode chars

### DIFF
--- a/src/Rules/MarkdownMaxChars.php
+++ b/src/Rules/MarkdownMaxChars.php
@@ -29,7 +29,8 @@ class MarkdownMaxChars implements Rule
     public function passes($attribute, $value)
     {
         $text = $this->getText($value);
-        return strlen($text) <= $this->maxChars;
+
+        return mb_strlen($text) <= $this->maxChars;
     }
 
     private function getText($value): string

--- a/tests/Rules/MarkdownMaxCharsTest.php
+++ b/tests/Rules/MarkdownMaxCharsTest.php
@@ -63,6 +63,23 @@ HTML;
     $this->assertFalse($rule->passes('markdown', $text));
 });
 
+
+it('validates unicode text correctly', function () {
+    $text = '⡷⡷⡷';
+
+    $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) {
+        $mock->shouldReceive('convertToHtml')
+            ->andReturn('⡷⡷⡷');
+    });
+
+    $rule = new MarkdownMaxChars(3);
+    $this->assertTrue($rule->passes('markdown', $text));
+
+    $rule = new MarkdownMaxChars(2);
+    $this->assertFalse($rule->passes('markdown', $text));
+});
+
+
 it('has an error message', function () {
     $rule = new MarkdownMaxChars(30);
     expect($rule->message())->toBe(trans('ui::validation.custom.max_markdown_chars', ['max' => 30]));


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The max chars rule for markdown is incorrectly counting the number of character when using unicode text like the one used on the ticket, this PR fixes that and adds a regression test.

To test merge this on msq and paste the text from the ticket.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [x] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
