### PR TITLE
fix: break works on user tagger to prevent horizontal growing

### DIFF
--- a/resources/views/inputs/user-tagger.blade.php
+++ b/resources/views/inputs/user-tagger.blade.php
@@ -37,7 +37,7 @@
             <div
                 wire:ignore
                 x-ref="editor"
-                style="min-height: {{ $rows * 30 }}px"
+                style="min-height: {{ $rows * 30 }}px; word-break: break-word;"
                 class="input-text @error($name) input-text--error @enderror"
                 data-placeholder="{{ $placeholder }}"
             >{{ $slot ?? '' }}</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g77wua

Adds a `word-break` style to the user tagger component to prevent it from growing with larger words like the one on the video.


To test add a review and fill it with a large word without spaces like `aaaaaaaaaa......etc....etc` if the world is large enough it should break the word on the next line.

![image](https://user-images.githubusercontent.com/17262776/112552086-20e14600-8dba-11eb-9cd1-e75db8315f99.png)

Note: you may ask why I am not using the `break-words` class and its because it simply didn't work, that class adds the `overflow-wrap: break-word;` instead of `word-break: break-word` and it doesn't work.

Another option was to create a CSS style for this field but figure out that this field already has inline styles and will be better just to add another style instead of growing the CSS stylesheet.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged


