### PR TITLE
fix: trim markdown text before counting

### DIFF
--- a/src/Rules/MarkdownMaxChars.php
+++ b/src/Rules/MarkdownMaxChars.php
@@ -39,7 +39,7 @@ class MarkdownMaxChars implements Rule
 
         $html = $this->removeHeadersAnchors($html);
 
-        return strip_tags($html);
+        return trim(strip_tags($html));
     }
 
     private function removeHeadersAnchors($html): string

--- a/tests/Rules/MarkdownMaxCharsTest.php
+++ b/tests/Rules/MarkdownMaxCharsTest.php
@@ -47,22 +47,55 @@ digitos Clanis in arces si quodam barbare aut dicta.</p>
 <p>Animi verecundo gentes adversaque vultum equos maduere; terra petit solebas, et,
 iam <em>amnis</em> promissa miluus! Diomedeos ira atque facinus deus magnum legit
 <em>pariter</em>!</p>
-
 HTML;
-
 
     $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) use ($html) {
         $mock->shouldReceive('convertToHtml')
             ->andReturn($html);
     });
 
-    $rule = new MarkdownMaxChars(763);
+    $rule = new MarkdownMaxChars(762);
     $this->assertTrue($rule->passes('markdown', $text));
 
-    $rule = new MarkdownMaxChars(762);
+    $rule = new MarkdownMaxChars(761);
     $this->assertFalse($rule->passes('markdown', $text));
 });
 
+it('accepts the exact number of chars on the parameter', function () {
+    $text = str_repeat('a', 100);
+
+    $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) use ($text) {
+        $mock->shouldReceive('convertToHtml')
+            ->andReturn($text);
+    });
+
+    $rule = new MarkdownMaxChars(100);
+    $this->assertTrue($rule->passes('markdown', $text));
+});
+
+it('trims the whitespaces for counting', function () {
+    $text = str_repeat('a', 100);
+
+    $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) use ($text) {
+        $mock->shouldReceive('convertToHtml')
+            ->andReturn($text . "\n");
+    });
+
+    $rule = new MarkdownMaxChars(100);
+    $this->assertTrue($rule->passes('markdown', $text));
+});
+
+it('doesnt accepts on extra chars from the parameter', function () {
+    $text = str_repeat('a', 11);
+
+    $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) use ($text) {
+        $mock->shouldReceive('convertToHtml')
+            ->andReturn($text);
+    });
+
+    $rule = new MarkdownMaxChars(10);
+    $this->assertFalse($rule->passes('markdown', $text));
+});
 
 it('validates unicode text correctly', function () {
     $text = '⡷⡷⡷';

--- a/tests/Rules/MarkdownMaxCharsTest.php
+++ b/tests/Rules/MarkdownMaxCharsTest.php
@@ -85,7 +85,7 @@ it('trims the whitespaces for counting', function () {
     $this->assertTrue($rule->passes('markdown', $text));
 });
 
-it('doesnt accepts on extra chars from the parameter', function () {
+it('doesnt accepts more characters than the limit', function () {
     $text = str_repeat('a', 11);
 
     $this->mock(MarkdownConverterInterface::class, function (MockInterface $mock) use ($text) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/gd0exq

To fix the characters count I am updating the rule for max chars on markdown text to ignore whitespace resulted from the text conversion.

To test create a review and first add exactly `1001` chars => you should see a validation error
Then try with exactly 1000 chars  => it should pass the validation

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   x ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
