### PR TITLE
feat: add option for modals with a fixed position

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -23,7 +23,7 @@
     @if(!$closeButtonOnly && $wireClose)
         wire:click.self="{{ $wireClose }}"
     @endif
-    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
+    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
     @if(!$closeButtonOnly && $escToClose)
         wire:keydown.escape="{{ $wireClose }}"
         tabindex="0"

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -10,6 +10,7 @@
     'closeButtonOnly' => false,
     'wireClose' => false,
     'escToClose' => true,
+    'fixedPosition' => false,
 ])
 
 <div class="fixed inset-0 z-50 opacity-75 bg-theme-secondary-900 dark:bg-theme-secondary-800 dark:opacity-50"></div>
@@ -22,14 +23,14 @@
     @if(!$closeButtonOnly && $wireClose)
         wire:click.self="{{ $wireClose }}"
     @endif
-    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
+    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
     @if(!$closeButtonOnly && $escToClose)
         wire:keydown.escape="{{ $wireClose }}"
         tabindex="0"
     @endif
 >
     <div
-        class="modal-content-wrapper md:m-auto w-full {{ $class }} {{ $widthClass }}"
+        class="modal-content-wrapper @if($fixedPosition) md:mx-auto @else md:m-auto @endif w-full {{ $class }} {{ $widthClass }}"
         @if($style) style="{{ $style }}" @endif
     >
         <div class="modal-content dropdown-scrolling {{ $widthClass }}">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

New option for modals with "fixed" position

When set, the modal will be not centered vertical but will be shown on the top of the page (with a margin) this will fix a jump that happens when the modal content change (like the modal for editing a project tag that changes his size within the autocomplete)

For test instructions and screenshots see the related ticket on msq: https://github.com/ArkEcosystem/marketsquare.io/pull/1641

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design, and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements, and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
