### PR TITLE
fix: infinite loop in tag component when mismatching case

### DIFF
--- a/resources/assets/js/tags.js
+++ b/resources/assets/js/tags.js
@@ -16,7 +16,9 @@ const Tags = (
 
         const taggle = new Taggle(input, {
             tags,
-            preserveCase,
+            // If we have a list of allowed tags we are preserving the case
+            // since the valid options are handled by the array.
+            preserveCase: preserveCase || allowedTags.length > 0,
             maxTags,
             placeholder,
             containerFocusClass: "tags-input-focus",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/r995tu

The tags component script has a `allowedTags` options that expect an array of the tags that can be used, (currently used on project registration > "add platform") since in a recent PR  the case preservation was disabled the script is currently creating a loop in the process of picking an element to the list that have some elements with uppercase letters.

This PR updates the `preserveCase` to be enabled if we have a list of valid options.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
