### PR TITLE
fix: store & keep scroll position on tile show more

### DIFF
--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -31,7 +31,7 @@
             this.currrentScroll = document.documentElement.scrollTop;
             this.mobileHidden = false;
             this.$nextTick(() => {
-                document.scrollTo(0, this.currrentScroll);
+                window.scrollTo(0, this.currrentScroll);
             });
         }
     }"

--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -26,6 +26,14 @@
     x-data="{
         selectedOption: @if ($single) '{{ $this->{$model ?? $id} }}' @else null @endif,
         mobileHidden: true,
+        currrentScroll: null,
+        showMore() {
+            this.currrentScroll = document.documentElement.scrollTop;
+            this.mobileHidden = false;
+            this.$nextTick(() => {
+                document.scrollTo(0, this.currrentScroll);
+            });
+        }
     }"
 >
     <div class="{{ $wrapperClass }}">
@@ -70,7 +78,7 @@
         <div
             class="py-3 font-semibold text-center rounded bg-theme-primary-100 text-theme-primary-600 sm:hidden"
             x-bind:class="{ hidden: ! mobileHidden }"
-            @click="mobileHidden = false"
+            @click="showMore"
         >
             @lang('ui::general.show_more')
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/gb2thc

When using the tiles component "show button" button (for example, on project registration) now it will store the scroll position to prevent the browser to make a jump that may represent a UX problem, especially on mobile where the user can lose the view.

To test: on mobile screen create a new project, select a platform and then press the "show more" button for the categories, you should keep your scroll position, it doesn't matter what was the initial position when "show more" was pressed

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
