### PR TITLE
fix: remove conflicting alpine x-model on tiles component

### DIFF
--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="flex relative flex-col"
+    class="relative flex flex-col"
     x-bind:class="{
         @if ($mobileHidden) 'hidden sm:flex': mobileHidden, @endif
     }"
@@ -9,11 +9,12 @@
     @endif
     <label
         dusk="tile-selection-label-{{ $option['id'] }}"
-        wire:key="tile-selection-option-{{ $option['id'] }}"
+        for="{{ $id.'-'.$option['id'] }}"
+        wire:key="tile-selection-option-{{ $id.'-'.$option['id'] }}"
         class="{{ $single ? 'tile-selection-single' : 'tile-selection-option' }} {{ $isDisabled && ! $option['checked'] ? 'disabled-tile' : '' }}"
         x-bind:class="{
             @if ($single)
-                'tile-selection--checked': '{{ $option['id'] }}' === selectedOption,
+                'tile-selection--checked': {{ $this->{$wireModel ?? $id} === $option['id'] ? 'true': 'false' }},
             @else
                 'tile-selection--checked': {{ $option['checked'] ? 'true' : 'false' }},
             @endif
@@ -25,10 +26,11 @@
                 name="{{ $id }}"
                 type="radio"
                 class="sr-only"
-                x-model="selectedOption"
                 value="{{ $option['id'] }}"
                 wire:model="{{ $wireModel }}"
-                :checked="'{{ $option['id'] }}' === selectedOption"
+                @if($this->{$wireModel ?? $id} === $option['id'])
+                    checked="checked"
+                @endif
             />
         @else
             <input

--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="relative flex flex-col"
+    class="flex relative flex-col"
     x-bind:class="{
         @if ($mobileHidden) 'hidden sm:flex': mobileHidden, @endif
     }"

--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -24,7 +24,6 @@
     wire:key="tile-selection-{{ $id }}"
     class="space-y-4 {{ $class }}"
     x-data="{
-        selectedOption: @if ($single) '{{ $this->{$model ?? $id} }}' @else null @endif,
         mobileHidden: true,
     }"
 >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/gb2thc

The x-model that was being used on the tile component was causing a re-render on the tiles that will resetting the show more button, refactored to fix the problem

To test add this to msq and try to replicate the issues from the ticket.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [X] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
