### PR TITLE
feat: add table row focus classes

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -256,8 +256,45 @@
     > tbody
     > tr:hover
     > td.hoverable-cell
+    > div.table-cell-bg,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:first-child
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.first-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:last-child
+    > div.table-cell-bg:before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.last-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell
     > div.table-cell-bg {
     @apply bg-theme-secondary-100;
+}
+
+.table-container
+    table
+    > tbody
+    > tr:focus {
+        @apply outline-none;
 }
 
 .table-container
@@ -288,6 +325,36 @@
     table
     > tbody
     > tr[data-danger]:hover
+    > td.hoverable-cell
+    > div.table-cell-bg,
+.table-container
+    table
+    > tbody
+    > tr[data-danger]:focus
+    > td.hoverable-cell:first-child
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-danger]:focus
+    > td.hoverable-cell.first-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-danger]:focus
+    > td.hoverable-cell:last-child
+    > div.table-cell-bg:before,
+.table-container
+    table
+    > tbody
+    > tr[data-danger]:focus
+    > td.hoverable-cell.last-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-danger]:focus
     > td.hoverable-cell
     > div.table-cell-bg {
     @apply bg-theme-danger-100;
@@ -321,6 +388,36 @@
     table
     > tbody
     > tr[data-warning]:hover
+    > td.hoverable-cell
+    > div.table-cell-bg,
+    .table-container
+    table
+    > tbody
+    > tr[data-warning]:focus
+    > td.hoverable-cell:first-child
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-warning]:focus
+    > td.hoverable-cell.first-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-warning]:focus
+    > td.hoverable-cell:last-child
+    > div.table-cell-bg:before,
+.table-container
+    table
+    > tbody
+    > tr[data-warning]:focus
+    > td.hoverable-cell.last-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr[data-warning]:focus
     > td.hoverable-cell
     > div.table-cell-bg {
     @apply bg-theme-warning-100;
@@ -359,6 +456,41 @@
     table
     > tbody
     > tr:hover
+    > td.hoverable-cell
+    > div.table-cell-bg,
+    .dark
+    .table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:first-child
+    > div.table-cell-bg::before,
+.dark
+    .table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.first-cell
+    > div.table-cell-bg::before,
+.dark
+    .table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:last-child
+    > div.table-cell-bg:before,
+.dark
+    .table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.last-cell
+    > div.table-cell-bg::before,
+.dark
+    .table-container
+    table
+    > tbody
+    > tr:focus
     > td.hoverable-cell
     > div.table-cell-bg {
     @apply bg-theme-secondary-800 !important;

--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -290,11 +290,8 @@
     @apply bg-theme-secondary-100;
 }
 
-.table-container
-    table
-    > tbody
-    > tr:focus {
-        @apply outline-none;
+.table-container table > tbody > tr:focus {
+    @apply outline-none;
 }
 
 .table-container
@@ -390,7 +387,7 @@
     > tr[data-warning]:hover
     > td.hoverable-cell
     > div.table-cell-bg,
-    .table-container
+.table-container
     table
     > tbody
     > tr[data-warning]:focus
@@ -458,7 +455,7 @@
     > tr:hover
     > td.hoverable-cell
     > div.table-cell-bg,
-    .dark
+.dark
     .table-container
     table
     > tbody


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/qk5yjc

Used here https://github.com/ArkEcosystem/marketsquare.io/pull/1732

If we add a `tabindex` to a row it means it can be focused using tab navigation, in that case, I am applying the same styles used when hovering the mouse:

![image](https://user-images.githubusercontent.com/17262776/114222966-dc66b600-9934-11eb-9d15-cef1d72e87f8.png)



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
