### PR TITLE
feat: move external link with confirmation modal to the ui library

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -13,7 +13,7 @@
             Livewire.emit('openModal', '{{ $identifier }}')
         }
     }"
-    class="inline-flex items-center space-x-2 font-semibold cursor-pointer whitespace-nowrap link"
+    class="inline-flex items-center space-x-2 font-semibold whitespace-nowrap cursor-pointer link"
     @click="openModal"
 >
     <span>{{ $text ?? $slot ?? '' }}</span>

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -1,0 +1,69 @@
+@props([
+    'url',
+    'text' => null,
+    'noIcon' => false,
+])
+
+@php($identifier = md5($url . '-' . Str::random(8)))
+
+<a
+    href="javascript:;"
+    x-data="{
+        openModal() {
+            Livewire.emit('openModal', '{{ $identifier }}')
+        }
+    }"
+    class="inline-flex items-center space-x-2 font-semibold cursor-pointer whitespace-nowrap link"
+    @click="openModal"
+>
+    <span>{{ $text ?? $slot ?? '' }}</span>
+
+    @unless($noIcon)
+        <x-ark-icon name="link" size="sm" class="mx-2" />
+    @endunless
+</a>
+
+@push('footer')
+    <x-ark-js-modal
+        :name="$identifier"
+        class="w-full max-w-2xl text-left rounded-lg"
+        title-class="header-2"
+        buttons-style="flex justify-end space-x-3"
+        init
+    >
+        @slot('title')
+            @lang('generic.external_link')
+        @endslot
+
+        @slot('description')
+            <div class="flex flex-col space-y-4 whitespace-normal">
+                <p>
+                    @lang('generic.external_link_warning')
+                </p>
+                <div class="font-semibold text-theme-secondary-900">
+                    <x-ark-alert type="warning" :message="$url" />
+                </div>
+                <p>@lang('generic.external_link_disclaimer')</p>
+            </div>
+        @endslot
+
+        @slot('buttons')
+            <button
+                class="button-secondary"
+                @click="hide"
+            >
+                @lang('actions.back')
+            </button>
+
+            <a
+                target="_blank"
+                rel="noopener nofollow"
+                class="cursor-pointer button-primary"
+                href="{{ $url }}"
+                @click="hide"
+            >
+                @lang('actions.follow_link')
+            </a>
+        @endslot
+    </x-ark-js-modal>
+@endpush

--- a/src/UserInterfaceServiceProvider.php
+++ b/src/UserInterfaceServiceProvider.php
@@ -219,6 +219,7 @@ class UserInterfaceServiceProvider extends ServiceProvider
         Blade::component('ark::expandable', 'ark-expandable');
         Blade::component('ark::expandable-item', 'ark-expandable-item');
         Blade::component('ark::external-link', 'ark-external-link');
+        Blade::component('ark::external-link-confirm', 'ark-external-link-confirm');
         Blade::component('ark::flash', 'ark-flash');
         Blade::component('ark::footer-bar-desktop', 'ark-footer-bar-desktop');
         Blade::component('ark::footer-bar-mobile', 'ark-footer-bar-mobile');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Needed for using on the fortify package (see https://github.com/ArkEcosystem/laravel-fortify/pull/124)



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
