### PR TITLE
feat: hide tooltips on scrolling

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -10,13 +10,13 @@ const tooltipSettings = {
     onShown: (instance) => {
         visibleTooltips.push(instance);
     },
-    onHidden: (instance,e) => {
-        const index = visibleTooltips.findIndex(i => i.id === instance.id);
+    onHidden: (instance, e) => {
+        const index = visibleTooltips.findIndex((i) => i.id === instance.id);
         if (index >= 0) {
             visibleTooltips.splice(index, 1);
         }
-    }
-}
+    },
+};
 
 tippy("[data-tippy-content]", tooltipSettings);
 
@@ -27,7 +27,9 @@ tippy("[data-tippy-hover]", {
     content: (reference) => reference.dataset.tippyHover,
 });
 
-document.addEventListener('scroll', () => visibleTooltips.forEach((instance) => instance.hide(0)));
+document.addEventListener("scroll", () =>
+    visibleTooltips.forEach((instance) => instance.hide(0))
+);
 
 window.initClipboard = () => {
     tippy(".clipboard", {

--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -1,18 +1,33 @@
 import tippy from "tippy.js";
 import "tippy.js/dist/tippy.css";
 
+const visibleTooltips = [];
+
 /** Enable tooltips for components with this data attribute, and global config options */
-tippy("[data-tippy-content]", {
+const tooltipSettings = {
     trigger: "mouseenter focus",
     duration: 0,
-});
+    onShown: (instance) => {
+        visibleTooltips.push(instance);
+    },
+    onHidden: (instance,e) => {
+        const index = visibleTooltips.findIndex(i => i.id === instance.id);
+        if (index >= 0) {
+            visibleTooltips.splice(index, 1);
+        }
+    }
+}
+
+tippy("[data-tippy-content]", tooltipSettings);
 
 tippy("[data-tippy-hover]", {
+    ...tooltipSettings,
     touch: "hold",
     trigger: "mouseenter",
     content: (reference) => reference.dataset.tippyHover,
-    duration: 0,
 });
+
+document.addEventListener('scroll', () => visibleTooltips.forEach((instance) => instance.hide(0)));
 
 window.initClipboard = () => {
     tippy(".clipboard", {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/gv1bvu
as the title says

Test by triggering a tooltip on mobile, it should disappear when you scroll the page

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
