### PR TITLE
fix: add wire:key to prevent livewire issues on toast notifications

### DIFF
--- a/resources/views/livewire/toast.blade.php
+++ b/resources/views/livewire/toast.blade.php
@@ -1,4 +1,4 @@
-<div class="fixed bottom-0 right-0 z-50 grid grid-rows-1 gap-2 mb-5 mr-1" style="min-width: 250px; max-width: 350px">
+<div class="grid fixed right-0 bottom-0 z-50 grid-rows-1 gap-2 mr-1 mb-5" style="min-width: 250px; max-width: 350px">
     @foreach ($toasts as $key => $toast)
         <div
             class="z-20 cursor-pointer"

--- a/resources/views/livewire/toast.blade.php
+++ b/resources/views/livewire/toast.blade.php
@@ -1,10 +1,11 @@
-<div class="grid fixed right-0 bottom-0 z-50 grid-rows-1 gap-2 mr-1 mb-5" style="min-width: 250px; max-width: 350px">
+<div class="fixed bottom-0 right-0 z-50 grid grid-rows-1 gap-2 mb-5 mr-1" style="min-width: 250px; max-width: 350px">
     @foreach ($toasts as $key => $toast)
         <div
             class="z-20 cursor-pointer"
             x-data="{ dismiss() { livewire.emit('dismissToast', '{{ $key }}' ) } }"
             x-init="() => setTimeout(() => dismiss(), 5000);"
             @click="dismiss()"
+            wire:key="{{ $key }}"
         >
             <x-ark-toast :type="$toast['type']" wire-close="dismissToast('{{ $key }}')">
                 <x-slot name='message'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g98vmk

Added `wire:key` attribute to the toasts to fix the issue described on the ticket.

To test just follow the steps on the ticket

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
