### PR TITLE
fix: add overridable blur & focus events to the markdown editor

### DIFF
--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -148,6 +148,8 @@ const MarkdownEditor = (
                 initialValue: input.value,
                 events: {
                     change: () => this.onChangeHandler(),
+                    blur: this.onBlur,
+                    focus: this.onFocus,
                 },
                 toolbarItems: this.toolbarItems,
                 plugins: this.getPlugins(),
@@ -395,6 +397,14 @@ const MarkdownEditor = (
         });
 
         input.dispatchEvent(event);
+    },
+
+    onBlur: () => {
+        // Nothing to do, used to be overriden with the x-data
+    },
+
+    onFocus: () => {
+        // Nothing to do, used to be overriden with the x-data
     },
 
     ...extraData,

--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -399,13 +399,9 @@ const MarkdownEditor = (
         input.dispatchEvent(event);
     },
 
-    onBlur: () => {
-        // Nothing to do, used to be overriden with the x-data
-    },
-
-    onFocus: () => {
-        // Nothing to do, used to be overriden with the x-data
-    },
+    // Default handlers
+    onBlur: () => {},
+    onFocus: () => {},
 
     ...extraData,
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Add an `onFocus` and `onBlur` methods on the markdown editor scripts, those are meant to be overridden in case we want to add some behaviour.

Use case: validate the project description until blur (on this PR https://github.com/ArkEcosystem/marketsquare.io/pull/1793)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
