### PR TITLE
fix: reset temporary images on error

### DIFF
--- a/src/Components/UploadImageCollection.php
+++ b/src/Components/UploadImageCollection.php
@@ -51,6 +51,8 @@ trait UploadImageCollection
                 $this->uploadError($error);
             }
 
+            $this->temporaryImages = [];
+
             $validator->validate();
 
             return false;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

After the user tries to upload an invalid image the `temporaryImages` variable is not being reset which means that if you use methods like `$this->getErrorBag()->isEmpty()` on a livewire component you will have at least that error even that you will not see any warning.

In this PR line (https://github.com/ArkEcosystem/marketsquare.io/pull/1795/files#diff-cddbaf63976b6d41bfc27e2f3bf773be7cd26df1469f5f55f29892d11e1a75eeR129) I am using that method to know if the form has any error so if the user tries to upload an invalid image even that the image will not be added to the form the user will be unable to save the form.

To test open the PR, upload an invalid image the "save" button will be disabled.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [X] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
