### PR TITLE
fix: truncate long tags in tag component

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -75,14 +75,14 @@
 }
 
 .input-text-with-prefix {
-    @apply block w-full transition-default rounded appearance-none border-0 border-theme-danger-500 outline-none;
+    @apply block w-full border-0 rounded outline-none appearance-none transition-default border-theme-danger-500;
 
     /* Note: need this to override form-input padding */
     padding: 0.75rem 1rem;
 }
 
 .input-wrapper-with-prefix {
-    @apply flex rounded border border-theme-secondary-300 bg-white;
+    @apply flex bg-white border rounded border-theme-secondary-300;
 }
 
 .input-wrapper-with-prefix .input-prefix-icon {
@@ -94,7 +94,7 @@
 }
 
 .input-wrapper-with-prefix .input-prefix {
-    @apply bg-theme-primary-50 text-theme-secondary-500 border-r border-theme-secondary-300 select-none;
+    @apply border-r select-none bg-theme-primary-50 text-theme-secondary-500 border-theme-secondary-300;
 }
 
 /* Radio buttons */
@@ -223,7 +223,7 @@
 }
 
 .taggle_list .taggle {
-    @apply flex items-center pl-2 pr-1 space-x-2 rounded bg-theme-primary-100;
+    @apply flex items-center pl-2 pr-1 space-x-2 overflow-auto rounded bg-theme-primary-100;
     padding-top: 0.25rem !important;
     padding-bottom: 0.25rem !important;
 }
@@ -259,7 +259,7 @@
 }
 
 .taggle_text {
-    @apply text-theme-primary-600;
+    @apply truncate text-theme-primary-600;
 }
 
 .taggle {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/hd8fvd

Truncates the tags when are longer than the available space 

![image](https://user-images.githubusercontent.com/17262776/115263842-5ea46680-a0fb-11eb-9110-e6bb9fce1f51.png)

![image](https://user-images.githubusercontent.com/17262776/115263862-649a4780-a0fb-11eb-8c19-f848e8ec6921.png)

To test just update this dependency on msq and add a long tag (30 chars) in a small screen 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
