### PR TITLE
fix: tag input on small screen

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -249,7 +249,8 @@
 }
 
 .taggle_input {
-    @apply w-0 my-1 bg-none;
+    width: 1ch;
+    @apply max-w-full my-1 bg-none;
 }
 
 .taggle_sizer {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This will fix a small issue on Tag input (on small viewport or on small modal window), that hide the caret and the input text (see video below).

https://user-images.githubusercontent.com/2118799/115403135-6e4fa800-a1ec-11eb-8c06-8027c6347f55.mov

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
