### PR TITLE
fix: use ui breadcrumb on 404 page

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -11,7 +11,7 @@
     @endsection
 
     @section('content')
-        <div class="flex flex-col items-center justify-center space-y-8">
+        <div class="flex flex-col justify-center items-center space-y-8">
             <img src="/images/errors/404.svg" class="max-w-4xl"/>
             <div class="text-lg font-semibold text-center text-theme-secondary-900">Something went wrong, please try again later or get in touch if the issue persists!</div>
             <div class="space-x-3">

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -4,14 +4,14 @@
     @endpush
 
     @section('breadcrumbs')
-        <x-breadcrumbs :crumbs="[
+        <x-ark-breadcrumbs :crumbs="[
             ['route' => 'home', 'label' => trans('menus.home')],
             ['label' => trans('menus.error.404')],
         ]" />
     @endsection
 
     @section('content')
-        <div class="flex flex-col justify-center items-center space-y-8">
+        <div class="flex flex-col items-center justify-center space-y-8">
             <img src="/images/errors/404.svg" class="max-w-4xl"/>
             <div class="text-lg font-semibold text-center text-theme-secondary-900">Something went wrong, please try again later or get in touch if the issue persists!</div>
             <div class="space-x-3">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/jk8452

The error described on the ticket is related to the published 404 page is trying to use a local breadcrumb component, this PR updates it to use the ui component instead

In case you are wondering that breadcrumb is the correct one, is even the one being used on the explorer 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
