### PR TITLE
fix: revert slider padding changes and move navbar-container to class

### DIFF
--- a/resources/assets/css/_general.css
+++ b/resources/assets/css/_general.css
@@ -20,6 +20,17 @@
     }
 }
 
+/* Navbar container */
+.navbar-container {
+    @apply px-8 py-0.5;
+}
+
+@screen sm {
+    .navbar-container {
+        @apply px-10;
+    }
+}
+
 /** Headings with H **/
 h1,
 h2,

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -30,7 +30,7 @@
         dusk="navigation-bar"
     >
         <div
-            class="navbar-container relative z-10 bg-white border-theme-secondary-300 md:border-none"
+            class="relative z-10 bg-white navbar-container border-theme-secondary-300 md:border-none"
             :class="{
                 'border-b': open
             }"

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -30,7 +30,7 @@
         dusk="navigation-bar"
     >
         <div
-            class="px-8 sm:px-10 py-0.5 relative z-10 bg-white border-theme-secondary-300 md:border-none"
+            class="navbar-container relative z-10 bg-white border-theme-secondary-300 md:border-none"
             :class="{
                 'border-b': open
             }"

--- a/resources/views/slider.blade.php
+++ b/resources/views/slider.blade.php
@@ -30,12 +30,12 @@
             class="swiper-container
                 @unless ($topPagination) slider-pagination-bottom @endunless
                 @if ($hasViewAll) slider-show-view-all @endif
-                @if ($shadowSpacing) px-8 sm:px-10 @endif
+                @if ($shadowSpacing) px-5 @endif
                 @if ($rows > 1) slider-multirow @endif"
         >
             @include('ark::includes.slider.header')
 
-            <div class="@if($shadowSpacing) px-8 sm:px-10 pt-5 -mx-8 sm:-mx-10 -mt-5 @endif swiper-wrapper">
+            <div class="@if($shadowSpacing) px-5 pt-5 -mx-5 -mt-5 @endif swiper-wrapper">
                 {{ $slot }}
             </div>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
