### PR TITLE
fix: navbar border

### DIFF
--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -23,18 +23,10 @@
     <nav
         aria-label="{{ trans('ark::general.primary_navigation') }}"
         x-ref="nav"
-        class="fixed top-0 z-30 w-full bg-white dark:bg-theme-secondary-900 border-theme-secondary-300"
-        :class="{
-            'border-b': !open
-        }"
+        class="fixed top-0 z-30 w-full bg-white dark:bg-theme-secondary-900 border-b border-theme-secondary-300"
         dusk="navigation-bar"
     >
-        <div
-            class="relative z-10 bg-white navbar-container border-theme-secondary-300"
-            :class="{
-                'border-b': open
-            }"
-        >
+        <div class="relative z-10 bg-white navbar-container border-theme-secondary-300">
             <div class="flex relative justify-between h-20">
                 @include('ark::navbar.logo')
 

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -23,7 +23,7 @@
     <nav
         aria-label="{{ trans('ark::general.primary_navigation') }}"
         x-ref="nav"
-        class="fixed top-0 z-30 w-full bg-white dark:bg-theme-secondary-900 border-b border-theme-secondary-300"
+        class="fixed top-0 z-30 w-full bg-white border-b dark:bg-theme-secondary-900 border-theme-secondary-300"
         dusk="navigation-bar"
     >
         <div class="relative z-10 bg-white navbar-container border-theme-secondary-300">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/jq8eh5

This will fix the navbar border bottom on every viewport size and even when we open the dropdown with a page scrolled (since we hide the border when the page starts to be scrolled).

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
