### PR TITLE
fix: proper spacing in responsive "table" rows

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -72,7 +72,7 @@
 
 /* Table List */
 .table-list-mobile-row {
-    @apply flex flex-col w-full py-6 space-y-4 border-t border-theme-secondary-300;
+    @apply flex flex-col w-full py-6 space-y-6 border-t border-theme-secondary-300;
 }
 .table-list-mobile-row:first-child {
     @apply pt-0 border-t-0;
@@ -571,7 +571,7 @@
 * needs
 */
 .table-container table.sticky-headers th {
-    @apply sticky z-5 bg-white bg-clip-padding;
+    @apply sticky bg-white z-5 bg-clip-padding;
     box-shadow: inset 0 -1px 0 var(--theme-color-secondary-300);
     /* Define this on your local project CSS file */
     /* top: 80px; */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

According to the design, the space between the rows should `24px` be and not `16px` as its currently is, related to this PR https://github.com/ArkEcosystem/explorer.ark.io/pull/730

Before:
![image](https://user-images.githubusercontent.com/17262776/120555365-940dc680-c3c0-11eb-80ef-466d53a3d9b2.png)


After:
![image](https://user-images.githubusercontent.com/17262776/120555316-83f5e700-c3c0-11eb-9ab0-86425d0d5f6c.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
