### PR TITLE
feat: get the scrollable element to lock from an overridable method

### DIFF
--- a/resources/assets/js/modal.js
+++ b/resources/assets/js/modal.js
@@ -4,18 +4,18 @@ import {
     clearAllBodyScrollLocks,
 } from "body-scroll-lock";
 
-const onModalClosed = (modal) => {
-    enableBodyScroll(modal);
+const onModalClosed = (scrollable) => {
+    enableBodyScroll(scrollable);
 
     if (!document.querySelectorAll("[data-modal]").length) {
         clearAllBodyScrollLocks();
     }
 };
 
-const onModalOpened = (modal) => {
-    disableBodyScroll(modal);
+const onModalOpened = (scrollable) => {
+    disableBodyScroll(scrollable);
 
-    modal.focus();
+    scrollable.focus();
 };
 
 const Modal = {
@@ -28,8 +28,7 @@ const Modal = {
             onHidden: false,
             onShown: false,
             init() {
-                const { modal } = this.$refs;
-
+                const scrollable = this.getScrollable();
                 if (this.name) {
                     Livewire.on("openModal", (modalName) => {
                         if (this.name === modalName) {
@@ -53,19 +52,19 @@ const Modal = {
                                 this.onShown();
                             }
 
-                            onModalOpened(modal);
+                            onModalOpened(scrollable);
                         } else {
                             if (typeof this.onHidden === "function") {
                                 this.onHidden();
                             }
 
-                            onModalClosed(modal);
+                            onModalClosed(scrollable);
                         }
                     });
                 });
 
                 if (this.shown) {
-                    onModalOpened(modal);
+                    onModalOpened(scrollable);
                 }
             },
             hide() {
@@ -74,21 +73,29 @@ const Modal = {
             show() {
                 this.shown = true;
             },
+            getScrollable() {
+                const { modal } = this.$refs;
+                return modal;
+            },
             ...extraData,
         };
     },
     livewire(extraData = {}) {
         return {
             init() {
-                const { modal } = this.$refs;
+                const scrollable = this.getScrollable();
 
                 this.$wire.on("modalClosed", () => {
                     this.$nextTick(() => {
-                        onModalClosed(modal);
+                        onModalClosed(scrollable);
                     });
                 });
 
-                onModalOpened(modal);
+                onModalOpened(scrollable);
+            },
+            getScrollable() {
+                const { modal } = this.$refs;
+                return modal;
             },
             ...extraData,
         };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/x1hed4

The script for the modal now gets the element that will be scrollable (while the rest of the page is locked) from a method so we can potentially override it.

Use case: explorer search modal, see explorer PR: https://github.com/ArkEcosystem/explorer.ark.io/pull/778/files

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
