### PR TITLE
refactor: update toggle component design to match style guide

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -130,12 +130,6 @@
     background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='gray' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
 }
 
-/* Toggle */
-
-.input-toggle-button {
-    --tw-ring-color: rgb(62, 157, 255, 0.5);
-}
-
 /* Switch (toggle alternative) */
 .input-switch-button-left {
     @apply translate-x-0 bg-theme-primary-600;

--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -133,9 +133,8 @@
 /* Toggle */
 
 .input-toggle-button {
-    --tw-ring-color:rgb(62, 157, 255, 0.5);
+    --tw-ring-color: rgb(62, 157, 255, 0.5);
 }
-
 
 /* Switch (toggle alternative) */
 .input-switch-button-left {

--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -131,30 +131,11 @@
 }
 
 /* Toggle */
-.input-toggle-slide {
-    @apply absolute h-2 mx-auto transition-colors duration-200 ease-in-out rounded-full w-9 bg-theme-secondary-300;
-}
-.dark .input-toggle-slide {
-    @apply bg-theme-secondary-800;
-}
 
 .input-toggle-button {
-    @apply absolute left-0 inline-block w-5 h-5 transition-transform duration-200 ease-in-out transform bg-white rounded-full shadow;
+    --tw-ring-color:rgb(62, 157, 255, 0.5);
 }
 
-.input-toggle-button-active {
-    @apply translate-x-5 bg-theme-primary-600;
-}
-.input-toggle-button-active:hover {
-    @apply ring;
-}
-
-.input-toggle-button-inactive {
-    @apply translate-x-0 bg-theme-secondary-300;
-}
-.dark .input-toggle-button-inactive {
-    @apply bg-theme-secondary-700;
-}
 
 /* Switch (toggle alternative) */
 .input-switch-button-left {

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -47,6 +47,9 @@ module.exports = {
             zIndex: {
                 "5": 5,
             },
+            ringColor: {
+                'focus': 'rgba(var(--theme-color-primary-rgb), 0.50)',
+            }
         },
 
         colors: {

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -48,8 +48,8 @@ module.exports = {
                 "5": 5,
             },
             ringColor: {
-                'focus': 'rgba(var(--theme-color-primary-rgb), 0.50)',
-            }
+                focus: "rgba(var(--theme-color-primary-rgb), 0.50)",
+            },
         },
 
         colors: {

--- a/resources/views/inputs/toggle.blade.php
+++ b/resources/views/inputs/toggle.blade.php
@@ -15,7 +15,7 @@
     @endunless
 
     <span
-        class="relative inline-flex items-center justify-center flex-shrink-0 w-8 h-5 outline-none ring-0"
+        class="inline-flex relative flex-shrink-0 justify-center items-center w-8 h-5 ring-0 outline-none"
         role="checkbox"
         @focus="focused=true"
         @blur="focused=false"
@@ -32,7 +32,7 @@
                 'translate-x-full bg-theme-primary-600': value,
                 'translate-x-0 bg-theme-secondary-300 dark:bg-theme-secondary-700': !value,
             }"
-            class="absolute left-0 inline-block w-4 h-4 transition duration-200 ease-in-out transform bg-white rounded-full cursor-pointer"
+            class="inline-block absolute left-0 w-4 h-4 bg-white rounded-full transition duration-200 ease-in-out transform cursor-pointer"
         ></span>
     </span>
 

--- a/resources/views/inputs/toggle.blade.php
+++ b/resources/views/inputs/toggle.blade.php
@@ -1,5 +1,5 @@
 <div
-    x-data="{ value: {{ $default ?? 'false' }}, toggle() { this.value = !this.value; this.$refs['checkbox-livewire'].click(); }, focused: false }"
+    x-data="{ focused: false, value: {{ $default ?? 'false' }}, toggle() { this.value = !this.value; this.$refs['checkbox-livewire'].click(); } }"
     class="flex items-center"
 >
     @unless($hideLabel ?? false)
@@ -15,24 +15,27 @@
     @endunless
 
     <span
-        @focus="focused = true"
-        @blur="focused = false"
-        class="inline-flex relative flex-shrink-0 justify-center items-center w-10 h-5 cursor-pointer focus:outline-none"
+        class="relative inline-flex items-center justify-center flex-shrink-0 w-8 h-5 outline-none ring-0"
         role="checkbox"
-        tabindex="0"
-        @click="toggle()"
-        @keydown.space.prevent="toggle()"
+        @focus="focused=true"
+        @blur="focused=false"
         :aria-checked="value.toString()"
+        tabindex="0"
+        @click.prevent="toggle"
+        @keyup.space.prevent="toggle"
     >
-        <span aria-hidden="true" class="input-toggle-slide"></span>
+        <span aria-hidden="true" class="absolute w-full h-1.5 mx-auto transition-colors duration-200 ease-in-out rounded-full bg-theme-secondary-300 dark:bg-theme-secondary-800"></span>
         <span
             aria-hidden="true"
             :class="{
-                'input-toggle-button-active': value,
-                'input-toggle-button-inactive': !value
+                'ring outline-none': focused,
+                'translate-x-full bg-theme-primary-600': value,
+                'translate-x-0 bg-theme-secondary-300 dark:bg-theme-secondary-700': !value,
             }"
-            class="input-toggle-button"></span>
+            class="absolute left-0 inline-block w-4 h-4 transition duration-200 ease-in-out transform bg-white rounded-full cursor-pointer input-toggle-button"
+        ></span>
     </span>
+
     <input
         x-ref="checkbox-livewire"
         type="checkbox"

--- a/resources/views/inputs/toggle.blade.php
+++ b/resources/views/inputs/toggle.blade.php
@@ -28,11 +28,11 @@
         <span
             aria-hidden="true"
             :class="{
-                'ring outline-none': focused,
+                'ring ring-focus outline-none': focused,
                 'translate-x-full bg-theme-primary-600': value,
                 'translate-x-0 bg-theme-secondary-300 dark:bg-theme-secondary-700': !value,
             }"
-            class="absolute left-0 inline-block w-4 h-4 transition duration-200 ease-in-out transform bg-white rounded-full cursor-pointer input-toggle-button"
+            class="absolute left-0 inline-block w-4 h-4 transition duration-200 ease-in-out transform bg-white rounded-full cursor-pointer"
         ></span>
     </span>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/kkbc0k

Updates the toggle component according to the style guide including the focus state.

To test:
1. merge this on explorer,
2. recompile assets,
3. Try to navigate the settings dropdown with the keyboard, the toggle should have the same design as the style guide,  should be animated, and should have the ring for the focus state

![image](https://user-images.githubusercontent.com/17262776/121060768-b15bdf80-c788-11eb-8abc-45100a17f68c.png)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
