### PR TITLE
fix: large info icon styling

### DIFF
--- a/resources/views/info.blade.php
+++ b/resources/views/info.blade.php
@@ -10,8 +10,8 @@
     class="inline-block cursor-pointer {{ $large ? 'p-1.5' : 'p-1' }} transition-default rounded-full bg-theme-primary-100 text-theme-primary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 hover:text-white hover:bg-theme-primary-700 dark:hover:text-theme-secondary-800 dark:hover:bg-theme-secondary-600 {{ $class }}"
 >
     @if($type === 'question')
-        <x-ark-icon name="question-mark" size="{{ $large ? 'md' : 'xs' }}" />
+        <x-ark-icon name="question-mark" size="{{ $large ? 'sm' : 'xs' }}" />
     @else
-        <x-ark-icon name="hint" size="{{ $large ? 'md' : 'xs' }}" />
+        <x-ark-icon name="hint" size="{{ $large ? 'sm' : 'xs' }}" />
     @endif
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
