### PR TITLE
fix: disable profile photo delete button while busy

### DIFF
--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -88,7 +88,7 @@
         @if (!$image && !$readonly)
             <div
                 wire:key="upload-button"
-                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
+                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
                 role="button"
             >
                 <div class="text-theme-primary-500">
@@ -115,7 +115,7 @@
 
             >
                 <div
-                    class="absolute top-0 w-full h-full pointer-events-none rounded-xl opacity-70 border-6 border-theme-secondary-900 transition-default"></div>
+                    class="absolute top-0 w-full h-full rounded-xl opacity-70 pointer-events-none border-6 border-theme-secondary-900 transition-default"></div>
 
                 <button
                     wire:loading.attr="disabled"
@@ -129,7 +129,7 @@
             </div>
 
             <div x-show="isUploading" x-cloak>
-                <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions"/>
+                <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions"/>
             </div>
         @endunless
     </div>
@@ -157,7 +157,7 @@
                 </div>
             @endif
 
-            <div class="mt-8 -mx-8 sm:mt-10 sm:-mx-10 h-75">
+            <div class="-mx-8 mt-8 sm:mt-10 sm:-mx-10 h-75">
                 <img id="image-single-crop-{{ $id }}" src="" alt="">
             </div>
         @endslot

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -88,7 +88,7 @@
         @if (!$image && !$readonly)
             <div
                 wire:key="upload-button"
-                class="flex absolute top-2 right-2 bottom-2 left-2 flex-col justify-center items-center space-y-2 rounded-xl cursor-pointer pointer-events-none"
+                class="absolute flex flex-col items-center justify-center space-y-2 cursor-pointer pointer-events-none top-2 right-2 bottom-2 left-2 rounded-xl"
                 role="button"
             >
                 <div class="text-theme-primary-500">
@@ -115,19 +115,21 @@
 
             >
                 <div
-                    class="absolute top-0 w-full h-full rounded-xl opacity-70 pointer-events-none border-6 border-theme-secondary-900 transition-default"></div>
+                    class="absolute top-0 w-full h-full pointer-events-none rounded-xl opacity-70 border-6 border-theme-secondary-900 transition-default"></div>
 
-                <div
+                <button
+                    wire:loading.attr="disabled"
+                    type="button"
                     class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
                     wire:click="deleteImageSingle"
                     data-tippy-hover="{{ $deleteTooltip }}"
                 >
                     <x-ark-icon name="close" size="sm"/>
-                </div>
+                </button>
             </div>
 
             <div x-show="isUploading" x-cloak>
-                <x-ark-loading-spinner class="right-0 bottom-0 left-0 rounded-xl" :dimensions="$dimensions"/>
+                <x-ark-loading-spinner class="bottom-0 left-0 right-0 rounded-xl" :dimensions="$dimensions"/>
             </div>
         @endunless
     </div>
@@ -155,7 +157,7 @@
                 </div>
             @endif
 
-            <div class="-mx-8 mt-8 sm:mt-10 sm:-mx-10 h-75">
+            <div class="mt-8 -mx-8 sm:mt-10 sm:-mx-10 h-75">
                 <img id="image-single-crop-{{ $id }}" src="" alt="">
             </div>
         @endslot


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/mbccap

Disables the delete button while deleting to prevent double click

To test just merge this to msq and try to replicate the issue



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
