### PR TITLE
feat: lg shadow with less opacity

### DIFF
--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -18,7 +18,8 @@ module.exports = {
                     "2px 3px 10px 2px rgba(var(--theme-color-primary-rgb), 0.34)",
                 "button-secondary":
                     "2px 3px 10px 2px rgba(var(--theme-color-primary-rgb), 0.34)",
-                "lg-smooth": "0 10px 15px -3px rgba(0, 0, 0, 0.025), 0 4px 6px -2px rgba(0, 0, 0, 0.025)",
+                "lg-smooth":
+                    "0 10px 15px -3px rgba(0, 0, 0, 0.025), 0 4px 6px -2px rgba(0, 0, 0, 0.025)",
                 "header-smooth": " 0px 2px 10px 0px rgba(192, 200, 207, 0.22)",
                 "header-smooth-dark": " 0px 2px 10px 0px rgba(18, 18, 19, .6)",
                 "lg-dark":

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
                     "2px 3px 10px 2px rgba(var(--theme-color-primary-rgb), 0.34)",
                 "button-secondary":
                     "2px 3px 10px 2px rgba(var(--theme-color-primary-rgb), 0.34)",
+                "lg-smooth": "0 10px 15px -3px rgba(0, 0, 0, 0.025), 0 4px 6px -2px rgba(0, 0, 0, 0.025)",
                 "header-smooth": " 0px 2px 10px 0px rgba(192, 200, 207, 0.22)",
                 "header-smooth-dark": " 0px 2px 10px 0px rgba(18, 18, 19, .6)",
                 "lg-dark":


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/mb5pj7 and https://github.com/ArkEcosystem/explorer.ark.io/pull/835

Add a new lg shadow with less opacity for the search module on explorer

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
