### PR TITLE
refactor: allow unescaped messages for alert component

### DIFF
--- a/resources/views/alert.blade.php
+++ b/resources/views/alert.blade.php
@@ -1,10 +1,11 @@
 @props([
-    'class'        => '',
-    'message'      => null,
-    'messageClass' => 'text-sm',
-    'large'        => false,
-    'title'        => null,
-    'type'         => 'info',
+    'class'           => '',
+    'message'         => null,
+    'messageClass'    => 'text-sm',
+    'large'           => false,
+    'title'           => null,
+    'type'            => 'info',
+    'withoutEscaping' => false,
 ])
 
 <div {{
@@ -32,7 +33,7 @@
         @endif
 
         @isset($message)
-            <span class="block leading-6 {{ $messageClass }}">{{ $message }}</span>
+            <span class="block leading-6 {{ $messageClass }}">@if($withoutEscaping) {!! $message !!} @else {{ $message }} @endif</span>
         @else
             <span class="block {{ $messageClass }}">{{ $slot }}</span>
         @endif


### PR DESCRIPTION
## Summary

Related to https://app.clickup.com/t/mndh1t where I needed to be able to use `<strong></strong>` for the first sentence of the alert message.

## Checklist

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged