### PR TITLE
refactor: make use of ark-info component for the tooltip of input-label 

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,16 +10,18 @@ This file contains basic examples and explains the parameters that can be used f
 
 `<x-ark-input type="email" name="my-input" :label="trans('forms.email_address')" :value="old('email')" :errors="$errors" />`
 
-| Parameter   | Description                                                                      | Required |
-|-------------|----------------------------------------------------------------------------------|----------|
-| name        | input name, will also be used as `id` if none specified                          | yes      |
-| errors      | laravel error bag                                                                | yes      |
-| label       | label to be shown for the input, will use `trans(form.<name>)` if none specified | no       |
-| type        | input type, can be the general HTML types. Defaults to `text`                    | no       |
-| placeholder | placeholder value                                                                | no       |
-| value       | default value to show, can be used with laravel's `old('value')` functionality   | no       |
-| model       | livewire model to attach to                                                      | no       |
-| id          | id of the input, by default `name` is used                                       | no       |
+| Parameter     | Description                                                                      | Required |
+|---------------|----------------------------------------------------------------------------------|----------|
+| name          | input name, will also be used as `id` if none specified                          | yes      |
+| errors        | laravel error bag                                                                | yes      |
+| label         | label to be shown for the input, will use `trans(form.<name>)` if none specified | no       |
+| type          | input type, can be the general HTML types. Defaults to `text`                    | no       |
+| placeholder   | placeholder value                                                                | no       |
+| value         | default value to show, can be used with laravel's `old('value')` functionality   | no       |
+| model         | livewire model to attach to                                                      | no       |
+| id            | id of the input, by default `name` is used                                       | no       |
+| tooltip       | content of the tooltip, will be shown next to the label                          | no       |
+| tooltip-class | allows additional classes for the tooltip                                        | no       |
 
 ### Textarea
 
@@ -174,7 +176,7 @@ mix
     with-crop
     cropOptions="{
         aspectRatio: 1 / 1,
-        ... 
+        ...
     }"
 />
 ```

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ import 'livewire-sortable'
 require('livewire-sortable')
 ```
 
-3. Add `imagesReordered` method to handle index reordering when an image is sorted. 
+3. Add `imagesReordered` method to handle index reordering when an image is sorted.
 
 ```php
 public function imagesReordered(array $ids): void
@@ -489,7 +489,7 @@ public function imagesReordered(array $ids): void
 }
 ```
 
-4. Then, you can use `upload-image-collection` component with sortable functionality. 
+4. Then, you can use `upload-image-collection` component with sortable functionality.
 
 ```blade
 <x-ark-upload-image-collection id="media" :images="$this->imageCollection" sortable />
@@ -527,7 +527,7 @@ There are also default error pages you can use for your Laravel project
 - `<x-ark-clipboard>`
 - `<x-ark-dropdown>`
 - [`<x-ark-expandable>`](EXAMPLES.md#expandable)
-- `<x-ark-input>`
+- [`<x-ark-input>`](EXAMPLES.md#input)
 - `<x-ark-navbar>`
 - `<x-ark-radio>`
 - `<x-ark-secondary-menu>`

--- a/resources/views/inputs/includes/input-label.blade.php
+++ b/resources/views/inputs/includes/input-label.blade.php
@@ -4,6 +4,7 @@
     'id'             => null,
     'label'          => null,
     'tooltip'        => null,
+    'customTooltip'  => null,
     'required'       => false,
     'auxiliaryTitle' => '',
 ])
@@ -24,5 +25,9 @@
 
     @if ($tooltip)
         <div class="input-tooltip" data-tippy-content="{{ $tooltip }}">?</div>
+    @endif
+
+    @if($customTooltip)
+        {{ $customTooltip }}
     @endif
 </label>

--- a/resources/views/inputs/includes/input-label.blade.php
+++ b/resources/views/inputs/includes/input-label.blade.php
@@ -1,12 +1,14 @@
 @props([
     'name',
     'errors',
-    'id'             => null,
-    'label'          => null,
-    'tooltip'        => null,
-    'customTooltip'  => null,
-    'required'       => false,
-    'auxiliaryTitle' => '',
+    'id'               => null,
+    'label'            => null,
+    'tooltip'          => null,
+    'tooltipClass'     => 'input-tooltip',
+    'tooltipIconsize'  => 'sm',
+    'tooltipType'      => 'info',
+    'required'         => false,
+    'auxiliaryTitle'   => '',
 ])
 
 <label
@@ -24,10 +26,12 @@
     @endif
 
     @if ($tooltip)
-        <div class="input-tooltip" data-tippy-content="{{ $tooltip }}">?</div>
-    @endif
-
-    @if($customTooltip)
-        {{ $customTooltip }}
+        <div class="{{ $tooltipClass }}" data-tippy-content="{{ $tooltip }}">
+            @if($tooltipType === 'info')
+                <x-ark-icon name="hint" :size="$tooltipIconSize" />
+            @else
+                <x-ark-icon name="question-mark" :size="$tooltipIconSize" />
+            @endif
+        </div>
     @endif
 </label>

--- a/resources/views/inputs/includes/input-label.blade.php
+++ b/resources/views/inputs/includes/input-label.blade.php
@@ -4,7 +4,7 @@
     'id'               => null,
     'label'            => null,
     'tooltip'          => null,
-    'tooltipClass'     => 'input-tooltip',
+    'tooltipClass'     => null,
     'tooltipType'      => 'info',
     'required'         => false,
     'auxiliaryTitle'   => '',

--- a/resources/views/inputs/includes/input-label.blade.php
+++ b/resources/views/inputs/includes/input-label.blade.php
@@ -5,7 +5,6 @@
     'label'            => null,
     'tooltip'          => null,
     'tooltipClass'     => 'input-tooltip',
-    'tooltipIconsize'  => 'sm',
     'tooltipType'      => 'info',
     'required'         => false,
     'auxiliaryTitle'   => '',
@@ -26,12 +25,6 @@
     @endif
 
     @if ($tooltip)
-        <div class="{{ $tooltipClass }}" data-tippy-content="{{ $tooltip }}">
-            @if($tooltipType === 'info')
-                <x-ark-icon name="hint" :size="$tooltipIconSize" />
-            @else
-                <x-ark-icon name="question-mark" :size="$tooltipIconSize" />
-            @endif
-        </div>
+        <x-ark-info :tooltip="$tooltip" :class="$tooltipClass" :type="$tooltipType" />
     @endif
 </label>

--- a/resources/views/inputs/input.blade.php
+++ b/resources/views/inputs/input.blade.php
@@ -8,7 +8,6 @@
                 'label'           => $label ?? null,
                 'tooltip'         => $tooltip ?? null,
                 'tooltipClass'    => $tooltipClass ?? null,
-                'tooltipIconSize' => $tooltipIconSize ?? null,
                 'tooltipType'     => $tooltipType ?? null,
                 'required'        => $required ?? false,
                 'auxiliaryTitle'  => $auxiliaryTitle ?? '',

--- a/resources/views/inputs/input.blade.php
+++ b/resources/views/inputs/input.blade.php
@@ -7,6 +7,7 @@
                 'id'             => $id ?? $name,
                 'label'          => $label ?? null,
                 'tooltip'        => $tooltip ?? null,
+                'customTooltip'  => $customTooltip ?? null,
                 'required'       => $required ?? false,
                 'auxiliaryTitle' => $auxiliaryTitle ?? '',
             ])

--- a/resources/views/inputs/input.blade.php
+++ b/resources/views/inputs/input.blade.php
@@ -2,14 +2,16 @@
     <div class="input-group">
         @unless ($hideLabel ?? false)
             @include('ark::inputs.includes.input-label', [
-                'name'           => $name,
-                'errors'         => $errors,
-                'id'             => $id ?? $name,
-                'label'          => $label ?? null,
-                'tooltip'        => $tooltip ?? null,
-                'customTooltip'  => $customTooltip ?? null,
-                'required'       => $required ?? false,
-                'auxiliaryTitle' => $auxiliaryTitle ?? '',
+                'name'            => $name,
+                'errors'          => $errors,
+                'id'              => $id ?? $name,
+                'label'           => $label ?? null,
+                'tooltip'         => $tooltip ?? null,
+                'tooltipClass'    => $tooltipClass ?? null,
+                'tooltipIconSize' => $tooltipIconSize ?? null,
+                'tooltipType'     => $tooltipType ?? null,
+                'required'        => $required ?? false,
+                'auxiliaryTitle'  => $auxiliaryTitle ?? '',
             ])
         @endunless
 


### PR DESCRIPTION
## Summary

Allow us to pass a custom tooltip, for example : 

```html
<x-ark-input>
     <x-slot name="customTooltip">
         <x-ark-info tooltip="hello" type="info" />
     </x-slot>
</x-ark-input>
```

## Checklist

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged