### PR TITLE
refactor: remove bitmap support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -209,6 +209,7 @@ mix
 | crop-image-smoothing-enabled | Set to change if images are smoothed                                             | no       |
 | crop-image-smoothing-quality | Set the quality of image smoothing, one of "low" (default), "medium", or "high"  | no       |
 | crop-endpoint                | Where to upload the image                                                        | no       |
+| accept-mime                  | List of comma separated mime types                                               | no       |
 
 #### Backend
 

--- a/config/ui.php
+++ b/config/ui.php
@@ -11,4 +11,8 @@ return [
         'folder'     => 'livewire-tmp',
         'disk'       => 'local',
     ],
+
+    'upload' => [
+        'accept-mime' => 'image/jpg,image/jpeg,image/png',
+    ],
 ];

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -8,6 +8,7 @@
     'minWidth'           => 148,
     'minHeight'          => 148,
     'maxFilesize'        => '2MB',
+    'acceptMime'         => (string) config('ui.upload.accept-mime'),
     'uploadErrorMessage' => null,
     'sortable'           => false,
 ])
@@ -25,7 +26,7 @@
             type="file"
             class="absolute w-full h-full opacity-0 cursor-pointer"
             wire:model="temporaryImages"
-            accept="image/jpg,image/jpeg,image/bmp,image/png"
+            accept="{{ $acceptMime }}"
             multiple
         />
 

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -11,7 +11,7 @@
     'width'                     => 450,
     'height'                    => 450,
     'maxFilesize'               => '2MB',
-    'acceptMime'                => 'image/jpg,image/jpeg,image/bmp,image/png',
+    'acceptMime'                => (string) config('ui.upload.accept-mime'),
     'readonly'                  => false,
     'uploadErrorMessage'        => null,
     'withCrop'                  => false,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/mx7m44

This PR prevents users from uploading "bitmap" images.
It modifies `upload-image-single` and `upload-image-collection` components.

It also makes mime-types configurable for easy access in the future.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
