### PR TITLE
chore: include toastui editor scripts locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ window.Modal = Modal;
 
 ### WYSIWYG Markdown editor
 
-1. Ensure to import the following scripts inside the `<head>` tag of your template.
+1. Install the npm dependencies
+
+```bash
+yarn add @toast-ui/editor@^2.5.2 codemirror@^5.62.0
+```
+
+2. Ensure to import the markdown script inside the `<head>` tag of your template.
 
 ```html
 @push('scripts')
@@ -123,26 +129,26 @@ window.Modal = Modal;
 
 Assigning to the `window` object is now done in the markdown script itself, therefore there is no need to import and assign this script manually!
 
-2. Import the markdown css file in your main file.
+3. Import the markdown css file in your main file.
 
 ```css
 @import "../../vendor/arkecosystem/ui/resources/assets/css/_markdown-editor.css";
 ```
 
-3. Compile the markdown scripts into the public folder:
+4. Compile the markdown scripts into the public folder:
 
 ```js
 mix
     .js('vendor/arkecosystem/ui/resources/assets/js/markdown-editor/markdown-editor.js', 'public/js/markdown-editor.js')
 ```
 
-4. Add the markdown component to your form
+5. Add the markdown component to your form
 
 ```html
 <x-ark-markdown name="about" />
 ```
 
-5. You can change the height and the toolbar preset:
+6. You can change the height and the toolbar preset:
 
 ```html
 <x-ark-markdown name="about"
@@ -151,7 +157,7 @@ mix
 />
 ```
 
-6. You can choose to limit the characters to be inserted:
+7. You can choose to limit the characters to be inserted:
 
 ```html
 <x-ark-markdown name="about"
@@ -161,7 +167,7 @@ mix
 
 Accepts `full` for all the plugins and `basic` for only text related buttons.
 
-7. If you use the image upload plugin your page will need to have the csrf_token in the metadata.
+8. If you use the image upload plugin your page will need to have the csrf_token in the metadata.
 
 ```html
 <meta name="csrf-token" content="{{ csrf_token() }}">

--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -1,3 +1,7 @@
+import Editor from '@toast-ui/editor';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import 'codemirror/lib/codemirror.css';
+
 import {
     simplecastPlugin,
     youtubePlugin,
@@ -17,7 +21,7 @@ import { extractTextFromHtml, uploadImage } from "./utils/utils.js";
 
 const AVERAGE_WORDS_READ_PER_MINUTE = 200;
 
-toastui.Editor.setLanguage(["en", "en-US"], {
+Editor.setLanguage(["en", "en-US"], {
     "Unordered list": "Unordered List",
     "Ordered list": "Ordered List",
     "Insert link": "Insert link",
@@ -129,17 +133,10 @@ const MarkdownEditor = (
                   "embedlink",
               ],
     init() {
-        if (typeof toastui === "undefined") {
-            alert(
-                "You need to add the editor scripts. See `laravel-ui` README for instructions."
-            );
-            return;
-        }
-
         try {
             const { input } = this.$refs;
 
-            this.editor = new toastui.Editor({
+            this.editor = new Editor({
                 el: this.$refs.editor,
                 initialEditType: "markdown",
                 usageStatistics: false,

--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -1,6 +1,6 @@
-import Editor from '@toast-ui/editor';
-import '@toast-ui/editor/dist/toastui-editor.css';
-import 'codemirror/lib/codemirror.css';
+import Editor from "@toast-ui/editor";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import "codemirror/lib/codemirror.css";
 
 import {
     simplecastPlugin,

--- a/resources/views/pages/includes/markdown-scripts.blade.php
+++ b/resources/views/pages/includes/markdown-scripts.blade.php
@@ -1,4 +1,1 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.min.css" />
-<script src="https://uicdn.toast.com/editor/2.5.2/toastui-editor-all.min.js" defer></script>
-<link rel="stylesheet" href="https://uicdn.toast.com/editor/2.5.2/toastui-editor-only.min.css" />
-<script src="{{ mix('js/markdown-editor.js')}}"></script>
+<script src="{{ mix('js/markdown-editor.js') }}"></script>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/n979q9
Changes the markdown script to import the toastui-related scripts locally to avoid cdns 

After merged check:
1. https://github.com/ArkEcosystem/ark.io/pull/963
2. https://github.com/ArkEcosystem/marketsquare.io/pull/2090

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [x] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
