### PR TITLE
fix: livewire corrupt payload excepton when using markdown

### DIFF
--- a/resources/views/inputs/markdown.blade.php
+++ b/resources/views/inputs/markdown.blade.php
@@ -58,7 +58,7 @@ $icons = [
                     {{ $xData }}
                 )"
                 x-init="init"
-                class="overflow-hidden bg-white border-2 rounded border-theme-secondary-200"
+                class="overflow-hidden bg-white rounded border-2 border-theme-secondary-200"
             >
                 <div x-show="showOverlay" class="fixed top-0 left-0 z-50 w-full h-full bg-black bg-opacity-75" style="display: none"></div>
                 <div>

--- a/resources/views/inputs/markdown.blade.php
+++ b/resources/views/inputs/markdown.blade.php
@@ -58,7 +58,7 @@ $icons = [
                     {{ $xData }}
                 )"
                 x-init="init"
-                class="overflow-hidden bg-white rounded border-2 border-theme-secondary-200"
+                class="overflow-hidden bg-white border-2 rounded border-theme-secondary-200"
             >
                 <div x-show="showOverlay" class="fixed top-0 left-0 z-50 w-full h-full bg-black bg-opacity-75" style="display: none"></div>
                 <div>
@@ -74,13 +74,13 @@ $icons = [
                     @endforeach
                 </div>
 
-                <input
+                <textarea
                     x-ref="input"
-                    type="hidden"
+                    style="display: none"
                     id="{{ $id ? $id : $name }}"
                     name="{{ $name }}"
                     wire:model="{{ $model ? $model : $name }}"
-                />
+                ></textarea>
 
                 <div wire:ignore x-ref="editor"></div>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please ensure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

https://app.clickup.com/t/z9epbf
https://sentry.io/organizations/ark-ecosystem/issues/2392277890/events/30f7edb06b7049aba350936fcba37af0/?project=5387309

I was unable to reproduce the exception. However, I strongly believe the change I am submitting will fix the potential errors:

Explanation: the markdown component uses JS to update the value of a text `<input  />` added outside the markdown component while the user types. That input is used to emulate the `wire:model` behavior.

As you can see in the video below, the value is added to the `value` attribute every time you update the markdown content. The problem is that it is creating a lot of content with JS, which is potentially the reason for the corrupt view exception. 

I changed the input for a `textarea` that doesn't add any `value`  attribute when the value Is assigned with JS. That means that the HTML is not affected, which means livewire shouldn't have any issue related to corrupt data.

https://user-images.githubusercontent.com/17262776/123855352-6c3d5000-d8e5-11eb-9637-c6341eaa3f1f.mov

Test by updating this dependency on msq

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design, and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
