### PR TITLE
refactor: use php arrays for define the slider breakpoints

### DIFF
--- a/resources/views/includes/slider/scripts.blade.php
+++ b/resources/views/includes/slider/scripts.blade.php
@@ -5,36 +5,7 @@
             slidesPerGroup: 1,
             slidesPerColumn: 1,
             spaceBetween: {{ $spaceBetween }},
-            @if($breakpoints)
-                breakpoints: {!! $breakpoints !!},
-            @else
-                breakpoints: {
-                    @if ($columns > 1)
-                    375: {
-                        slidesPerGroup: {{ $columns - 3 > 0 ? $columns - 3 : 2 }},
-                        slidesPerView: {{ $columns - 3 > 0 ? $columns - 3 : 2 }},
-                    },
-                    640: {
-                        slidesPerGroup: {{ $columns - 2 > 0 ? $columns - 2 : 3 }},
-                        slidesPerView: {{ $columns - 2 > 0 ? $columns - 2 : 3 }}
-                    },
-                    1024: {
-                        slidesPerGroup: {{ $columns - 1 > 0 ? $columns - 1 : 4 }},
-                        slidesPerView: {{ $columns - 1 > 0 ? $columns - 1 : 4 }}
-                    },
-                    1280: {
-                    @else
-                    1024: {
-                    @endif
-                        slidesPerGroup: {{ $columns }},
-                        slidesPerView: {{ $columns }},
-                        @if ($rows > 1)
-                            slidesPerColumn: {{ $rows }},
-                            slidesPerColumnFill: 'row',
-                        @endif
-                    },
-                },
-            @endif
+            breakpoints: {!! json_encode($breakpoints) !!},
             loop: {{ $loop ? 'true' : 'false' }},
             loopFillGroupWithBlank: true,
             @if ($autoplay)

--- a/resources/views/slider.blade.php
+++ b/resources/views/slider.blade.php
@@ -22,10 +22,42 @@
 ])
 
 @php
+    if ($breakpoints === null ) {
+        if ($columns > 1) {
+            $breakpoints = [
+                '375' => [
+                    'slidesPerGroup' => $columns - 3 > 0 ? $columns - 3 : 2,
+                    'slidesPerView' => $columns - 3 > 0 ? $columns - 3 : 2,
+                ],
+                '640' => [
+                    'slidesPerGroup' => $columns - 2 > 0 ? $columns - 2 : 3,
+                    'slidesPerView' => $columns - 2 > 0 ? $columns - 2 : 3,
+                ],
+                '1024' => [
+                    'slidesPerGroup' =>  $columns - 1 > 0 ? $columns - 1 : 4,
+                    'slidesPerView' =>  $columns - 1 > 0 ? $columns - 1 : 4,
+                ],
+                '1280' => [
+                    'slidesPerGroup' => $columns,
+                    'slidesPerView' => $columns,
+                ],
+            ];
+        } else  {
+            $breakpoints = [
+                '1024' => [
+                    'slidesPerGroup' => $columns,
+                    'slidesPerView' => $columns,
+                ],
+            ];
+        }
+
+        if ($rows > 1) {
+            $breakpoints[$columns > 1 ? '1280' : '1024']['slidesPerColumn'] = $rows;
+            $breakpoints[$columns > 1 ? '1280' : '1024']['slidesPerColumnFill'] = 'row';
+        }
+    }
 
     $hasViewAll = $viewAllUrl && ! $hideViewAll;
-
-    $slidesBreakpoints = extractSlidesBreakpoints($breakpoints);
 
     $classesPerBreakpoint = collect([
         '0' => [
@@ -56,16 +88,9 @@
         ],
     ]);
 
-    $gridClasses = $classesPerBreakpoint->map(function ($classes, $breakpoint) use ($slidesBreakpoints)  {
-        $key = $slidesBreakpoints->get($breakpoint);
-
-        if (!$key) {
-            return null;
-        }
-
-        return $classes[$key];
-    })->filter(fn($className) => !!$className)->join(' ');
-
+    $gridClasses = $classesPerBreakpoint
+        ->map(fn ($classes, $breakpoint) => Arr::get($classes, Arr::get($breakpoints, $breakpoint . '.slidesPerView', '')))
+        ->filter(fn($className) => !!$className)->join(' ');
 @endphp
 
 <div class="w-full">

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -47,16 +47,3 @@ if (! function_exists('clearZalgoText')) {
         return preg_replace("|[\p{M}]|uis","", $zalgo);
     }
 }
-
-if (! function_exists('extractSlidesBreakpoints')) {
-    function extractSlidesBreakpoints(string $str): Collection
-    {
-        $regex = '/(?<breakpoint>\d+):\s{[^}]*(?>slidesPerView:\s+(?<slidesPerView>\d+))[^}]*}/m';
-
-        preg_match_all($regex, $str, $matches, PREG_SET_ORDER, 0);
-
-        return collect($matches)->mapWithKeys(function ($match) {
-            return [$match['breakpoint'] => $match['slidesPerView']];
-        });
-    }
-}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to:
https://app.clickup.com/t/44rfxb

<strike>Currently, the ark website is broken (develop branch) because the slider view doesn't handle `null` breakpoints</strike>
The ark website will be broken once we update the UI dependency because the slider component doesn't handle `null` breakpoints.

While working on the fix figure out that the current solution for handling the breakpoints (that uses regex to parse the JS breakpoints) is not ideal since is easy to get the breakpoints as an array and then convert it to JS on the scripts view.

That also makes it easy to solve the issue on the ticket that was related to the default breakpoints and plus adds the grid classes that prevent any `jump` on the sliders that currently is not applied to sliders without custom breakpoints.

To test merge this on the msq and ark.io PRs and ensure all the sliders are still working as is used to be:
1. https://github.com/ArkEcosystem/ark.io/pull/967
2. https://github.com/ArkEcosystem/marketsquare.io/pull/2095

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
