### PR TITLE
refactor: force https prefix when using urls

### DIFF
--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -195,6 +195,11 @@ const MarkdownEditor = (
                 },
             });
 
+            const events = this.editor.eventManager.events;
+            const handlers = events.get('command');
+            handlers.unshift(this.forceHttpsLinkHandler);
+            events.set('command', handlers);
+
             this.editor.getCodeMirror().setOption("lineNumbers", true);
 
             this.toolbar = this.editor.getUI().getToolbar();
@@ -305,6 +310,25 @@ const MarkdownEditor = (
         });
 
         return Object.values(plugins);
+    },
+    forceHttpsLinkHandler: (event, data) => {
+        if (event === "AddLink") {
+            if (/^\/\//.test(data.url)) {
+                data.url = "https:" + data.url;
+                return data;
+            }
+
+            if (/^\//.test(data.url)) {
+                return data;
+            }
+
+            if (!/^https?:\/\//.test(data.url)) {
+                data.url = "https://" + data.url;
+                return data;
+            }
+        }
+
+        return data;
     },
     addIconsToTheButtons() {
         const {

--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -196,9 +196,9 @@ const MarkdownEditor = (
             });
 
             const events = this.editor.eventManager.events;
-            const handlers = events.get('command');
+            const handlers = events.get("command");
             handlers.unshift(this.forceHttpsLinkHandler);
-            events.set('command', handlers);
+            events.set("command", handlers);
 
             this.editor.getCodeMirror().setOption("lineNumbers", true);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/nqczb0

This PR improves Markdown Editor to force https prefix when filling in urls.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
