### PR TITLE
fix: gallery sorting when creating a project

### DIFF
--- a/src/Components/UploadImageCollection.php
+++ b/src/Components/UploadImageCollection.php
@@ -97,13 +97,13 @@ trait UploadImageCollection
 
     public function updateImageOrder(array $order): void
     {
-        if (! method_exists($this, 'imagesReordered')) {
-            return;
-        }
-
         $this->imageCollection = collect($order)->map(function ($item) {
             return collect($this->imageCollection)->get($item['value']);
         })->toArray();
+
+        if (! method_exists($this, 'imagesReordered')) {
+            return;
+        }
 
         $orderedIds = collect($this->imageCollection)->map(fn ($item) => data_get($item, 'image.id'))->filter()->toArray();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/nz89ez

fix an issue that was causing the sorting is not to be applied when creating a project.

To test merge this on msq and try to sort the gallery images when **creating** a new project

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
