### PR TITLE
refactor: slider delay init property

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -584,3 +584,86 @@ Here follow you can see an example on how to use it:
 |---|---|---|---|
 | src | The source of the font file | yes | |
 | preconnect | The source of the css file linked to the font itself. Can be different from the font source. | no | null |
+
+### Slider
+
+Used for sliding different elements (e.g. images).
+
+```
+<x-ark-slider
+    id="news-articles"
+    title="News Articles"
+    title-tooltip="See all the latest articles here"
+    view-all-url="{{ $route }}"
+    space-between="24"
+    hide-navigation
+    top-pagination
+    breakpoints="[
+        '0' => [
+            'slidesPerGroup' => 1,
+            'slidesPerView' => 1,
+        ],
+        '768' => [
+            'slidesPerGroup' => 2,
+            'slidesPerView' => 2,
+        ],
+        '1280' => [
+            'slidesPerGroup' => 3,
+            'slidesPerView' => 3,
+        ],
+    ]"
+>
+    <x-ark-slider-slide>
+        <img src="logo.png" />
+    </x-ark-slider-slide>
+</x-ark-slider>
+```
+
+| Parameter       | Description                                                          | Required |
+|-----------------|----------------------------------------------------------------------|----------|
+| id              | Used for initialising the slider                                     | yes      |
+| title           | Text used for the slider title [null]                                | no       |
+| titleClass      | CSS classes for the title text if provided ['text-2xl']              | no       |
+| titleTooltip    | Tooltip to be shown next to the title [null]                         | no       |
+| viewAllUrl      | URL used to navigate to a dedicated page [null]                      | no       |
+| viewAllClass    | CSS classes for view all text ['']                                   | no       |
+| hideNavigation  | Option to hide navigation arrows on the left & right [false]         | no       |
+| hideBullets     | Option to hide pagination bullets [false]                            | no       |
+| topPagination   | Show pagination at the top instead of the bottom [false]             | no       |
+| paginationClass | CSS classes for pagination bullets ['']                              | no       |
+| rows            | How many rows the slider consists of. Only used if                   | no       |
+|                 |   breakpoints are not specified. [1]                                 |          |
+| columns         | How many columns the slider consists of. Only used if                | no       |
+|                 |   breakpoints are not specified. [5]                                 |          |
+| breakpoints     | Allow more advanced overriding of breakpoints [null]                 | no       |
+| spaceBetween    | How much space (in pixels) to have between each slide [0]            | no       |
+| loop            | Allow looping from start to end and vice versa [false]               | no       |
+| allowTouch      | Used for mobile [true]                                               | no       |
+| autoplay        | Enable automatic sliding [false]                                     | no       |
+| autoplayDelay   | How long to wait on each slider when autoplay is enabled [3000]      | no       |
+| hideViewAll     | Option to hide the view all text [false]                             | no       |
+| shadowSpacing   | Whether the slider should allow spacing for shadows [false]          | no       |
+| delayInit       | Delays initialisation of the slider. See below for example [false]   | no       |
+
+#### Delayed Initialisation Example (Alpine)
+
+```
+<div x-data="{}">
+    <a
+        class="link"
+        @click="$nextTick(() => { window.sliders['news-articles'].init() });"
+    >
+        Initialise Slider
+    </a>
+
+    <x-ark-slider
+        id="news-articles"
+        title="News Articles"
+        delay-init
+    >
+        <x-ark-slider-slide>
+            <img src="logo.png" />
+        </x-ark-slider-slide>
+    </x-ark-slider>
+</div>
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -589,7 +589,7 @@ Here follow you can see an example on how to use it:
 
 Used for sliding different elements (e.g. images).
 
-```html
+```blade
 <x-ark-slider
     id="news-articles"
     title="News Articles"
@@ -647,7 +647,7 @@ Used for sliding different elements (e.g. images).
 
 We use `$nextTick` here to make sure the UI is updated prior to initialising our slider, otherwise it may trigger too quickly.
 
-```html
+```blade
 <div x-data="{ hidden: true }">
     <a
         class="link"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -619,31 +619,29 @@ Used for sliding different elements (e.g. images).
 </x-ark-slider>
 ```
 
-| Parameter       | Description                                                          | Required |
-|-----------------|----------------------------------------------------------------------|----------|
-| id              | Used for initialising the slider                                     | yes      |
-| title           | Text used for the slider title [null]                                | no       |
-| titleClass      | CSS classes for the title text if provided ['text-2xl']              | no       |
-| titleTooltip    | Tooltip to be shown next to the title [null]                         | no       |
-| viewAllUrl      | URL used to navigate to a dedicated page [null]                      | no       |
-| viewAllClass    | CSS classes for view all text ['']                                   | no       |
-| hideNavigation  | Option to hide navigation arrows on the left & right [false]         | no       |
-| hideBullets     | Option to hide pagination bullets [false]                            | no       |
-| topPagination   | Show pagination at the top instead of the bottom [false]             | no       |
-| paginationClass | CSS classes for pagination bullets ['']                              | no       |
-| rows            | How many rows the slider consists of. Only used if                   | no       |
-|                 |   breakpoints are not specified. [1]                                 |          |
-| columns         | How many columns the slider consists of. Only used if                | no       |
-|                 |   breakpoints are not specified. [5]                                 |          |
-| breakpoints     | Allow more advanced overriding of breakpoints [null]                 | no       |
-| spaceBetween    | How much space (in pixels) to have between each slide [0]            | no       |
-| loop            | Allow looping from start to end and vice versa [false]               | no       |
-| allowTouch      | Used for mobile [true]                                               | no       |
-| autoplay        | Enable automatic sliding [false]                                     | no       |
-| autoplayDelay   | How long to wait on each slider when autoplay is enabled [3000]      | no       |
-| hideViewAll     | Option to hide the view all text [false]                             | no       |
-| shadowSpacing   | Whether the slider should allow spacing for shadows [false]          | no       |
-| delayInit       | Delays initialisation of the slider. See below for example [false]   | no       |
+| Parameter       | Description                                                                             | Required |
+|-----------------|-----------------------------------------------------------------------------------------|----------|
+| id              | Used for initialising the slider                                                        | yes      |
+| title           | Text used for the slider title [null]                                                   | no       |
+| titleClass      | CSS classes for the title text if provided ['text-2xl']                                 | no       |
+| titleTooltip    | Tooltip to be shown next to the title [null]                                            | no       |
+| viewAllUrl      | URL used to navigate to a dedicated page [null]                                         | no       |
+| viewAllClass    | CSS classes for view all text ['']                                                      | no       |
+| hideNavigation  | Option to hide navigation arrows on the left & right [false]                            | no       |
+| hideBullets     | Option to hide pagination bullets [false]                                               | no       |
+| topPagination   | Show pagination at the top instead of the bottom [false]                                | no       |
+| paginationClass | CSS classes for pagination bullets ['']                                                 | no       |
+| rows            | How many rows the slider consists of. Only used if breakpoints are not specified [1]    | no       |
+| columns         | How many columns the slider consists of. Only used if breakpoints are not specified [5] | no       |
+| breakpoints     | Allow more advanced overriding of breakpoints [null]                                    | no       |
+| spaceBetween    | How much space (in pixels) to have between each slide [0]                               | no       |
+| loop            | Allow looping from start to end and vice versa [false]                                  | no       |
+| allowTouch      | Used for mobile [true]                                                                  | no       |
+| autoplay        | Enable automatic sliding [false]                                                        | no       |
+| autoplayDelay   | How long to wait on each slider when autoplay is enabled [3000]                         | no       |
+| hideViewAll     | Option to hide the view all text [false]                                                | no       |
+| shadowSpacing   | Whether the slider should allow spacing for shadows [false]                             | no       |
+| delayInit       | Delays initialisation of the slider. See below for example [false]                      | no       |
 
 #### Delayed Initialisation Example (Alpine)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -589,7 +589,7 @@ Here follow you can see an example on how to use it:
 
 Used for sliding different elements (e.g. images).
 
-```
+```html
 <x-ark-slider
     id="news-articles"
     title="News Articles"
@@ -647,7 +647,7 @@ Used for sliding different elements (e.g. images).
 
 We use `$nextTick` here to make sure the UI is updated prior to initialising our slider, otherwise it may trigger too quickly.
 
-```
+```html
 <div x-data="{ hidden: true }">
     <a
         class="link"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -647,23 +647,30 @@ Used for sliding different elements (e.g. images).
 
 #### Delayed Initialisation Example (Alpine)
 
+We use `$nextTick` here to make sure the UI is updated prior to initialising our slider, otherwise it may trigger too quickly.
+
 ```
-<div x-data="{}">
+<div x-data="{ hidden: true }">
     <a
         class="link"
-        @click="$nextTick(() => { window.sliders['news-articles'].init() });"
+        @click="
+            hidden = false;
+            $nextTick(() => { window.sliders['news-articles'].init() });
+        "
     >
         Initialise Slider
     </a>
 
-    <x-ark-slider
-        id="news-articles"
-        title="News Articles"
-        delay-init
-    >
-        <x-ark-slider-slide>
-            <img src="logo.png" />
-        </x-ark-slider-slide>
-    </x-ark-slider>
+    <div x-bind:class="{ 'hidden': hidden }">
+        <x-ark-slider
+            id="news-articles"
+            title="News Articles"
+            delay-init
+        >
+            <x-ark-slider-slide>
+                <img src="logo.png" />
+            </x-ark-slider-slide>
+        </x-ark-slider>
+    </div>
 </div>
 ```

--- a/resources/views/includes/slider/scripts.blade.php
+++ b/resources/views/includes/slider/scripts.blade.php
@@ -1,55 +1,73 @@
+@props([
+    'delayInit' => false,
+])
+
 <script>
     (() => {
-        const swiper = new Swiper('#swiper-{{ $id }}', {
-            slidesPerView: 1,
-            slidesPerGroup: 1,
-            slidesPerColumn: 1,
-            spaceBetween: {{ $spaceBetween }},
-            breakpoints: {!! json_encode($breakpoints) !!},
-            loop: {{ $loop ? 'true' : 'false' }},
-            loopFillGroupWithBlank: true,
-            @if ($autoplay)
-            autoplay: {
-                delay: {{ $autoplayDelay }},
-            },
-            @endif
-            @unless ($hideBullets)
-            pagination: {
-                el: '#swiper-{{ $id }} .swiper-pagination',
-                clickable: true
-            },
-            @endif
-            @unless ($hideNavigation)
-            navigation: {
-                nextEl: '.swiper-{{ $id }}-pagination.swiper-button-next',
-                prevEl: '.swiper-{{ $id }}-pagination.swiper-button-prev'
-            },
-            @endunless
-            watchOverflow: true,
-            allowTouchMove: {{ $allowTouch ? 'true' : 'false' }},
-            on: {
-                beforeInit: function () {
-                    const wrapper = this.$el[0].querySelector('.swiper-wrapper');
-                    wrapper.classList.remove('grid');
-                    wrapper.removeAttribute('style');
+        const initSlider = () => {
+            const swiper = new Swiper('#swiper-{{ $id }}', {
+                slidesPerView: 1,
+                slidesPerGroup: 1,
+                slidesPerColumn: 1,
+                spaceBetween: {{ $spaceBetween }},
+                breakpoints: {!! json_encode($breakpoints) !!},
+                loop: {{ $loop ? 'true' : 'false' }},
+                loopFillGroupWithBlank: true,
+                @if ($autoplay)
+                autoplay: {
+                    delay: {{ $autoplayDelay }},
                 },
-            },
-        });
-
-        document.addEventListener('DOMContentLoaded', function() {
-            swiper.on('init', function () {
-                Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
+                @endif
+                @unless ($hideBullets)
+                pagination: {
+                    el: '#swiper-{{ $id }} .swiper-pagination',
+                    clickable: true
+                },
+                @endif
+                @unless ($hideNavigation)
+                navigation: {
+                    nextEl: '.swiper-{{ $id }}-pagination.swiper-button-next',
+                    prevEl: '.swiper-{{ $id }}-pagination.swiper-button-prev'
+                },
+                @endunless
+                watchOverflow: true,
+                allowTouchMove: {{ $allowTouch ? 'true' : 'false' }},
+                on: {
+                    beforeInit: function () {
+                        const wrapper = this.$el[0].querySelector('.swiper-wrapper');
+                        wrapper.classList.remove('grid');
+                        wrapper.removeAttribute('style');
+                    },
+                },
             });
 
-            swiper.on('slideChangeTransitionEnd', function () {
-                Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
-            });
+            document.addEventListener('DOMContentLoaded', function() {
+                swiper.on('init', function () {
+                    Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
+                });
 
-            swiper.on('snapGridLengthChange', function () {
-                Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
-            });
+                swiper.on('slideChangeTransitionEnd', function () {
+                    Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
+                });
 
-            Slider.setupKeyboardEvents(swiper);
-        });
+                swiper.on('snapGridLengthChange', function () {
+                    Slider.disableTabIndexOfInvisibleElements(this.$el[0], this.slides);
+                });
+
+                Slider.setupKeyboardEvents(swiper);
+            });
+        };
+
+        @if($delayInit)
+            if (window.sliders === undefined) {
+                window.sliders = {};
+            }
+
+            window.sliders['{{ $id }}'] = {
+                init: initSlider,
+            };
+        @else
+            initSlider();
+        @endif
     })();
 </script>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/p18gyk

This requires `window.sliders['slider-id'].init()` to be called elsewhere. E.g. for Alpine:

```js	
$nextTick(() => { window.sliders['slider-id'].init() });
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
