### PR TITLE
refactor: reposition dropdowns without event

### DIFF
--- a/resources/assets/js/reposition-dropdown.js
+++ b/resources/assets/js/reposition-dropdown.js
@@ -1,4 +1,4 @@
-window.addEventListener("DOMContentLoaded", () => {
+const repositionDropdowns = () => {
     const dropdownButtons = document.querySelectorAll(".dropdown-button");
     for (const button of dropdownButtons) {
         if (
@@ -29,4 +29,10 @@ window.addEventListener("DOMContentLoaded", () => {
                 "px";
         }
     }
-});
+};
+
+if (document.readyState !== 'loading') {
+    repositionDropdowns();
+} else {
+    document.addEventListener('DOMContentLoaded', repositionDropdowns);
+}

--- a/resources/assets/js/reposition-dropdown.js
+++ b/resources/assets/js/reposition-dropdown.js
@@ -31,8 +31,8 @@ const repositionDropdowns = () => {
     }
 };
 
-if (document.readyState !== 'loading') {
+if (document.readyState !== "loading") {
     repositionDropdowns();
 } else {
-    document.addEventListener('DOMContentLoaded', repositionDropdowns);
+    document.addEventListener("DOMContentLoaded", repositionDropdowns);
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/nzempw

If the event has already been triggered, it won't trigger again when declared. This checks for that scenario and runs instantly if needed

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
