### PR TITLE
fix: hide Edge's native password reveal icon

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -283,3 +283,9 @@
 .hide-number-input-arrows input[type="number"] {
     -moz-appearance: textfield;
 }
+
+/* Hides native eye icon for revealing password */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+    display: none;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/p9cnfc

Hides the icon for revealing the password that appears on Microsoft Edge based browsers.

To test merge this on any project like msq, recompile assets, and test any password input in an edge browser.

Note: if you use mac you can download a native version of the Edge browser for Mac

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [X] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
