### PR TITLE
fix: external link proper spacing

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -283,3 +283,9 @@
 .hide-number-input-arrows input[type="number"] {
     -moz-appearance: textfield;
 }
+
+/* Hides native eye icon for revealing password */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+    display: none;
+}

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -13,13 +13,13 @@
             Livewire.emit('openModal', '{{ $identifier }}')
         }
     }"
-    class="inline-flex items-center font-semibold break-all cursor-pointer link"
+    class="items-center font-semibold break-all cursor-pointer link"
     @click="openModal"
 >
     <span>{{ $text ?? $slot ?? '' }}</span>
 
     @unless($noIcon)
-        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1 -mt-0.5" />
+        <x-ark-icon name="link" size="sm" class="flex-shrink-0 inline ml-1 -mt-2" />
     @endunless
 </a>
 

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -13,13 +13,13 @@
             Livewire.emit('openModal', '{{ $identifier }}')
         }
     }"
-    class="inline-block items-center space-x-2 font-semibold break-all cursor-pointer link"
+    class="inline-flex items-center font-semibold break-all cursor-pointer link items-center"
     @click="openModal"
 >
     <span>{{ $text ?? $slot ?? '' }}</span>
 
     @unless($noIcon)
-        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 mr-2 ml-1 -mt-1" />
+        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1" />
     @endunless
 </a>
 

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -19,7 +19,7 @@
     <span>{{ $text ?? $slot ?? '' }}</span>
 
     @unless($noIcon)
-        <x-ark-icon name="link" size="sm" class="flex-shrink-0 inline ml-1 -mt-2" />
+        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1 -mt-2" />
     @endunless
 </a>
 

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -19,7 +19,7 @@
     <span>{{ $text ?? $slot ?? '' }}</span>
 
     @unless($noIcon)
-        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1 -mt-2" />
+        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1 -mt-1.5" />
     @endunless
 </a>
 

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -19,7 +19,7 @@
     <span>{{ $text ?? $slot ?? '' }}</span>
 
     @unless($noIcon)
-        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1" />
+        <x-ark-icon name="link" size="sm" class="inline flex-shrink-0 ml-1 -mt-0.5" />
     @endunless
 </a>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/pb9v24

Updates the external link component for using the proper space

### Before:
![image](https://user-images.githubusercontent.com/17262776/126351864-2fa12938-220c-4888-bbb6-4183dc0d057a.png)

### After:
![image](https://user-images.githubusercontent.com/17262776/126351809-fc3d43f2-7e3a-4d96-9726-3a3141241542.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
