### PR TITLE
refactor: password toggle masked option

### DIFF
--- a/resources/views/inputs/password-toggle.blade.php
+++ b/resources/views/inputs/password-toggle.blade.php
@@ -11,7 +11,6 @@
             },
         @else
             type: 'password',
-            style: '',
             toggle() {
                 this.show = !this.show;
                 this.show ? this.type = 'text' : this.type = 'password';
@@ -34,11 +33,11 @@
             <input
                 x-ref="password-input"
                 :type="type"
-                :style="style"
                 id="{{ $id ?? $name }}"
                 name="{{ $name }}"
                 class="input-text shifted @error($name) input-text--error @enderror {{ $inputClass ?? '' }}"
                 wire:model="{{ $model ?? $name }}"
+                @if($masked) :style="style" @endif
                 @if($max ?? false) maxlength="{{ $max }}" @endif
                 @if($value ?? false) value="{{ $value }}" @endif
                 @if($autofocus ?? false) autofocus @endif

--- a/resources/views/inputs/password-toggle.blade.php
+++ b/resources/views/inputs/password-toggle.blade.php
@@ -37,7 +37,7 @@
                 name="{{ $name }}"
                 class="input-text shifted @error($name) input-text--error @enderror {{ $inputClass ?? '' }}"
                 wire:model="{{ $model ?? $name }}"
-                @if($masked) :style="style" @endif
+                @if($masked ?? false) :style="style" @endif
                 @if($max ?? false) maxlength="{{ $max }}" @endif
                 @if($value ?? false) value="{{ $value }}" @endif
                 @if($autofocus ?? false) autofocus @endif

--- a/resources/views/inputs/password-toggle.blade.php
+++ b/resources/views/inputs/password-toggle.blade.php
@@ -1,7 +1,30 @@
-<div x-data="{ show: false, type: 'password', toggle() { this.show = !this.show; this.show ? this.type = 'text' : this.type = 'password'; } }" class="{{ $class ?? '' }}">
+<div
+    class="{{ $class ?? '' }}"
+    x-data="{
+        show: false,
+        @if($masked ?? false)
+            type: 'text',
+            style: '-webkit-text-security: disc;',
+            toggle() {
+                this.show = !this.show;
+                this.show ? this.style = '' : this.style = '-webkit-text-security: disc;';
+            },
+        @else
+            type: 'password',
+            style: '',
+            toggle() {
+                this.show = !this.show;
+                this.show ? this.type = 'text' : this.type = 'password';
+            },
+        @endif
+    }"
+>
     <div class="input-group">
         @if(!($hideLabel ?? false))
-            <label for="{{ $id ?? $name }}" class="input-label @error($name) input-label--error @enderror">
+            <label
+                for="{{ $id ?? $name }}"
+                class="input-label @error($name) input-label--error @enderror"
+            >
                 {{ ($label ?? '') ? $label : trans('forms.' . $name) }}
             </label>
         @endif
@@ -11,6 +34,7 @@
             <input
                 x-ref="password-input"
                 :type="type"
+                :style="style"
                 id="{{ $id ?? $name }}"
                 name="{{ $name }}"
                 class="input-text shifted @error($name) input-text--error @enderror {{ $inputClass ?? '' }}"

--- a/resources/views/inputs/password-toggle.blade.php
+++ b/resources/views/inputs/password-toggle.blade.php
@@ -47,7 +47,11 @@
             />
 
             {{--toggle--}}
-            <button type="button" class="right-0 px-4 input-icon text-theme-primary-300 rounded @error($name) text-theme-danger-500 @enderror" @click="toggle()">
+            <button
+                type="button"
+                class="right-0 px-4 input-icon text-theme-primary-300 rounded @error($name) text-theme-danger-500 @enderror"
+                @click="toggle()"
+            >
                 <span x-show="!show">@svg('view', 'w-5 h-5')</span>
                 <span x-show="show" x-cloak>@svg('hide', 'w-5 h-5')</span>
             </button>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/p5fgqb

Most line changes are just spreading out the properties to improve readability.

Added a property to mark the field as masked which uses styling to hide the characters for a "text" input field.

To test:

- with nodem, checkout https://github.com/ArkEcosystem/nodem/pull/115
- update fortify in composer.json to pull `dev-refactor/disable-2fa-modal as ...`
- update ui in composer.json to pull `dev-refactor/password-toggle-masked-option as ...`
- sign in/up pages should have a password field with `type="password"`
- login, go to http://nodem.test/user/settings/security
- enable 2fa
- click to open recovery codes modal
- password field should have `type="text"` but still hide the characters
- toggling show/hide password should also work

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
