### PR TITLE
refactor: view options component colour overrides

### DIFF
--- a/resources/views/tables/view-options.blade.php
+++ b/resources/views/tables/view-options.blade.php
@@ -1,10 +1,15 @@
+@props([
+    'selectedClasses'   => 'text-theme-danger-400 border-theme-danger-100',
+    'unselectedClasses' => 'text-theme-info-300 border-white',
+])
+
 <div class="items-center @if($showMobile ?? false) flex @else hidden md:flex @endif">
     <div
         :class="{
-            'text-theme-danger-400 border-theme-danger-100': tableView === 'grid',
-            'text-theme-info-300 border-white': tableView !== 'grid',
+            '{{ $selectedClasses }}': tableView === 'grid',
+            '{{ $unselectedClasses }}': tableView !== 'grid',
         }"
-        class="py-2 px-3 cursor-pointer text-theme-info-300 border-b-3"
+        class="py-2 px-3 cursor-pointer border-b-3"
         @click="tableView = 'grid'"
     >
         <x-ark-icon name="grid" />
@@ -12,10 +17,10 @@
 
     <div
         :class="{
-            'text-theme-danger-400 border-theme-danger-100': tableView === 'list',
-            'text-theme-info-300 border-white': tableView !== 'list',
+            '{{ $selectedClasses }}': tableView === 'list',
+            '{{ $unselectedClasses }}': tableView !== 'list',
         }"
-        class="py-2 px-3 cursor-pointer text-theme-info-300 border-b-3"
+        class="py-2 px-3 cursor-pointer border-b-3"
         @click="tableView = 'list'"
     >
         <x-ark-icon name="list" />

--- a/resources/views/tables/view-options.blade.php
+++ b/resources/views/tables/view-options.blade.php
@@ -1,9 +1,10 @@
 @props([
+    'showMobile'        => false,
     'selectedClasses'   => 'text-theme-danger-400 border-theme-danger-100',
     'unselectedClasses' => 'text-theme-info-300 border-white',
 ])
 
-<div class="items-center @if($showMobile ?? false) flex @else hidden md:flex @endif">
+<div class="items-center @if($showMobile) flex @else hidden md:flex @endif">
     <div
         :class="{
             '{{ $selectedClasses }}': tableView === 'grid',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/pnac4g

Updates the View Options component to allow the changing of default colours. Nodem has a different colour scheme so this needs to allow different colours here:

![image](https://user-images.githubusercontent.com/8069294/126984197-98d4b378-e25f-4086-a6c8-5da0cb93cfa9.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
