### PR TITLE
fix: table row with focus style

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -115,6 +115,10 @@
     @apply px-0 py-0.5;
 }
 
+.table-container table tbody tr {
+    @apply outline-none;
+}
+
 .table-container
     table
     > tbody
@@ -255,6 +259,39 @@
     table
     > tbody
     > tr:hover
+    > td.hoverable-cell
+    > div.table-cell-bg {
+    @apply bg-theme-secondary-100;
+}
+
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:first-child
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.first-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell:last-child
+    > div.table-cell-bg:before,
+.table-container
+    table
+    > tbody
+    > tr:focus
+    > td.hoverable-cell.last-cell
+    > div.table-cell-bg::before,
+.table-container
+    table
+    > tbody
+    > tr:focus
     > td.hoverable-cell
     > div.table-cell-bg {
     @apply bg-theme-secondary-100;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Currently, when you focus on a row it has a blue border that looks weird

The only use case I am aware is the search results modal, you can test it by:
1. opening marketquare search modal
2. Search for something that has more than 1 result 
3. Click `down` key to navigate the results, you will see the fix whether or not this patch was added

### Before:

![image](https://user-images.githubusercontent.com/17262776/127006455-70d29071-08b7-4a18-8e48-9a3275b2a18d.png)


### After: 

![Screen Shot 2021-07-26 at 9 27 31](https://user-images.githubusercontent.com/17262776/127006296-811388c5-7a68-4bff-b47b-0355a1761ce8.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
