### PR TITLE
fix: "switch" component logic

### DIFF
--- a/resources/views/inputs/switch.blade.php
+++ b/resources/views/inputs/switch.blade.php
@@ -23,8 +23,8 @@
         <span
             aria-hidden="true"
             :class="{
-                'input-switch-button-left': value,
-                'input-switch-button-right': !value
+                'input-switch-button-left': !value,
+                'input-switch-button-right': value
             }"
             class="inline-block absolute left-0 w-4 h-4 bg-white rounded-full transition duration-200 ease-in-out transform cursor-pointer"
         ></span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Related to https://app.clickup.com/t/pxbnfu

This PR brings back the "Switch" component natural behavior.
We assume that the right position is the active value and the left position is the inactive. 
The corresponding label has to be highlighted and follow the toggle (left label highlighted when the toggle is on the left and vice-versa).

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
