### PR TITLE
refactor: pass all attributes to the loader component

### DIFF
--- a/resources/views/loader-icon.blade.php
+++ b/resources/views/loader-icon.blade.php
@@ -1,4 +1,8 @@
-<svg class="animate-spin {{ $class ?? '' }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+@props ([
+    'pathClass' => '',
+])
+
+<svg {{ $attributes->class('animate-spin') }} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
     <circle class="opacity-75" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="{{ $pathClass ?? '' }}" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
 </svg>

--- a/resources/views/loader-icon.blade.php
+++ b/resources/views/loader-icon.blade.php
@@ -1,8 +1,9 @@
 @props ([
     'pathClass' => '',
+    'circleClass' => '',
 ])
 
 <svg {{ $attributes->class('animate-spin') }} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-    <circle class="opacity-75" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+    <circle class="opacity-75 {{ $circleClass ?? '' }}" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="{{ $pathClass ?? '' }}" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
 </svg>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR allows to pass all attributes to the SVG that have been passed to the component. Some attributes are left out that make no sense to update (SVG's viewbox). Makes it easer to pass stuff like `<x-ark-loader-icon wire:loading.remove />`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
