### PR TITLE
feat: add disabled state for dropdown and table view options

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -475,6 +475,7 @@ You can also get an alert with more padding and large icon by specifying `large`
 | wrapperClass | The class(es) applied to the wrapper element | no | '' |
 | dropdownContentClasses | The class(es) applied to the content container | no | null |
 | buttonTooltip | Apply the given text as button tooltip | no | null |
+| disabled | This Boolean attribute prevents the user from interacting with the component | no | false |
 
 ### Expandable
 Displays a defined number of items and hides the rest, showing a button to show/hide the hidden items.

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -9,6 +9,7 @@
     'dusk'                   => false,
     'buttonTooltip'          => null,
     'height'                 => null,
+    'disabled'               => false,
 ])
 
 <div
@@ -36,7 +37,9 @@
 >
     <div>
         <button
-            @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}"
+            type="button"
+            @unless($disabled) @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endunless
+            @if($disabled) disabled @endif
             :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }} }"
             class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
             @if($buttonTooltip)

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -38,13 +38,10 @@
     <div>
         <button
             type="button"
-            @unless($disabled) @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endunless
-            @if($disabled) disabled @endif
             :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }} }"
             class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
-            @if($buttonTooltip)
-                data-tippy-content="{{ $buttonTooltip }}"
-            @endif
+            @if($disabled) disabled @else @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif
+            @if($buttonTooltip) data-tippy-content="{{ $buttonTooltip }}" @endif
         >
             @if($button ?? false)
                 {{ $button }}

--- a/resources/views/tables/view-options.blade.php
+++ b/resources/views/tables/view-options.blade.php
@@ -2,28 +2,33 @@
     'showMobile'        => false,
     'selectedClasses'   => 'text-theme-danger-400 border-theme-danger-100',
     'unselectedClasses' => 'text-theme-info-300 border-white',
+    'disabled'          => false,
 ])
 
 <div class="items-center @if($showMobile) flex @else hidden md:flex @endif">
-    <div
+    <button
+        type="button"
         :class="{
             '{{ $selectedClasses }}': tableView === 'grid',
             '{{ $unselectedClasses }}': tableView !== 'grid',
         }"
-        class="py-2 px-3 cursor-pointer border-b-3"
-        @click="tableView = 'grid'"
+        class="py-2 px-3 border-b-3"
+        @unless ($disabled) @click="tableView = 'grid'" @endunless
+        @if ($disabled) disabled @endif
     >
         <x-ark-icon name="grid" />
-    </div>
+    </button>
 
-    <div
+    <button
+        type="button"
         :class="{
             '{{ $selectedClasses }}': tableView === 'list',
             '{{ $unselectedClasses }}': tableView !== 'list',
         }"
-        class="py-2 px-3 cursor-pointer border-b-3"
-        @click="tableView = 'list'"
+        class="py-2 px-3 border-b-3"
+        @unless ($disabled) @click="tableView = 'list'" @endunless
+        @if ($disabled) disabled @endif
     >
         <x-ark-icon name="list" />
-    </div>
+    </button>
 </div>

--- a/resources/views/tables/view-options.blade.php
+++ b/resources/views/tables/view-options.blade.php
@@ -13,8 +13,7 @@
             '{{ $unselectedClasses }}': tableView !== 'grid',
         }"
         class="py-2 px-3 border-b-3"
-        @unless ($disabled) @click="tableView = 'grid'" @endunless
-        @if ($disabled) disabled @endif
+        @if ($disabled) disabled @else @click="tableView = 'grid'" @endif
     >
         <x-ark-icon name="grid" />
     </button>
@@ -26,8 +25,7 @@
             '{{ $unselectedClasses }}': tableView !== 'list',
         }"
         class="py-2 px-3 border-b-3"
-        @unless ($disabled) @click="tableView = 'list'" @endunless
-        @if ($disabled) disabled @endif
+        @if ($disabled) disabled @else @click="tableView = 'list'" @endif
     >
         <x-ark-icon name="list" />
     </button>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/pnabvn

This PRs adds `disabled` state for "table view-options" and "dropdown".

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
