### PR TITLE
fix: remove bottom margin for nested ordered list

### DIFF
--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -143,7 +143,7 @@ code.hljs .hljs-ln-n {
 
 .documentation-content ol ol,
 .documentation-content ul ol {
-    @apply ml-4 list-outside;
+    @apply ml-4 list-outside mb-0;
     list-style-type: lower-latin;
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

On [this PR](https://github.com/ArkEcosystem/laravel-ui/pull/610) I removed the bottom margin for the nested unordered list but I missed the ordered list 

This PR removes the margin there too.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
