### PR TITLE
nref: allow custom attributes on notification dot

### DIFF
--- a/resources/views/notification-dot.blade.php
+++ b/resources/views/notification-dot.blade.php
@@ -3,6 +3,6 @@
     'color' => 'bg-theme-danger-400 border-theme-danger-400',
 ])
 
-<span class="notification-dot {{ $class }}">
+<span {{ $attributes->merge(['class' => 'notification-dot ' . $class]) }}>
     <span class="block w-1 h-1 rounded-full border-3 {{ $color }}"></span>
 </span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Allow custom attributes on the notification dot component<del>, used to add a tooltip here: https://github.com/ArkEcosystem/nodem/pull/157</del>

Update: Not used anymore but still an improvement

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
