### PR TITLE
refactor: make modal's close button not a submit button

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -38,6 +38,7 @@
             <div class="p-8 sm:p-10">
                 @if($wireClose)
                     <button
+                        type="button"
                         class="modal-close"
                         @if($wireClose ?? false) wire:click="{{ $wireClose }}" @endif
                     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

If you wrap a modal in the form tag, the close (X) button will be made a submit button, since HTML automatically sets `type="submit"` to a button element if wrapped in a form ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)), if no type is explicitly set. This PR makes the button of a "button" type, which prevents that.

I don't see this breaking anything because a modal's close button is never used to submit a form.

Let me know if it's necessary to create a ClickUp card for this.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
