### PR TITLE
refactor: allow checkbox text color to be overridden

### DIFF
--- a/resources/views/inputs/checkbox.blade.php
+++ b/resources/views/inputs/checkbox.blade.php
@@ -43,8 +43,8 @@
             />
         </div>
 
-        <div class="@if($right) pr-7 @else pl-7 @endif text-sm leading-5">
-            <label for="{{ $id ?? $name }}" class="text-theme-secondary-700 {{ $labelClasses }}">
+        <div class="@if($right) pr-7 @else pl-7 @endif text-sm text-theme-secondary-700 leading-5">
+            <label for="{{ $id ?? $name }}" class="{{ $labelClasses }}">
                 {{ $label ? $label : trans('forms.' . $name) }}
             </label>
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Since we have a few checkboxes whose label color needs to be overriden, this PR pulls the default text color class one element up. That way, the text color can still be overriden and it's defaulted to secondary-700.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
