### PR TITLE
fix: keep table view option button click attribute in DOM

### DIFF
--- a/resources/views/tables/view-options.blade.php
+++ b/resources/views/tables/view-options.blade.php
@@ -13,7 +13,8 @@
             '{{ $unselectedClasses }}': tableView !== 'grid',
         }"
         class="py-2 px-3 border-b-3"
-        @if ($disabled) disabled @else @click="tableView = 'grid'" @endif
+        @click="tableView = 'grid'"
+        @if ($disabled) disabled @endif
     >
         <x-ark-icon name="grid" />
     </button>
@@ -25,7 +26,8 @@
             '{{ $unselectedClasses }}': tableView !== 'list',
         }"
         class="py-2 px-3 border-b-3"
-        @if ($disabled) disabled @else @click="tableView = 'list'" @endif
+        @click="tableView = 'list'"
+        @if ($disabled) disabled @endif
     >
         <x-ark-icon name="list" />
     </button>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1cryrgr

When a button is used inside a Livewire component and the `@click` attribute is toggled between rendering can cause issue with Livewire. In this case toggling between `@click` and `disabled` causing a `DOMException` in livewire.js.

![image](https://user-images.githubusercontent.com/2118799/130067236-cdfb3eb1-c36e-4391-a2df-70b0b7cc4f7e.png)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
