### PR TITLE
refactor: prevent log in button wrapping on mobile

### DIFF
--- a/resources/views/navbar/content.blade.php
+++ b/resources/views/navbar/content.blade.php
@@ -13,13 +13,13 @@
         @include('ark::navbar.profile')
     @endisset
 @else
-    <div class="flex items-center ml-5 sm:ml-4 sm:space-x-6">
+    <div class="flex items-center sm:ml-4 sm:space-x-6">
         @if(Route::has('register'))
             <a href="{{ route('register') }}" class="hidden font-semibold sm:block link">@lang('actions.sign_up')</a>
         @endif
 
         @if(Route::has('login'))
-            <a href="{{ route('login') }}" class="button-secondary">@lang('actions.sign_in')</a>
+            <a href="{{ route('login') }}" class="button-secondary whitespace-nowrap">@lang('actions.sign_in')</a>
         @endif
     </div>
 @endauth

--- a/resources/views/navbar/content.blade.php
+++ b/resources/views/navbar/content.blade.php
@@ -19,7 +19,7 @@
         @endif
 
         @if(Route::has('login'))
-            <a href="{{ route('login') }}" class="button-secondary whitespace-nowrap">@lang('actions.sign_in')</a>
+            <a href="{{ route('login') }}" class="whitespace-nowrap button-secondary">@lang('actions.sign_in')</a>
         @endif
     </div>
 @endauth


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/z431xz

Prevents text wrapping on the log in button and updates the margin to give it more space on 360px screens

Dependant of https://github.com/ArkEcosystem/marketsquare.io/pull/2226

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [X] I provided a screenshot of my changes to the component _(if applicable)_
-   [x] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
