### PR TITLE
refactor: navbar hide separator property

### DIFF
--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -50,7 +50,9 @@
                         @endisset
                     </div>
 
-                    <span class="{{ $separatorClasses ?? 'hidden pr-2 border-l ml-7 h-7 border-theme-secondary-300 dark:border-theme-secondary-800 ' . $separatorBreakpointClass }}"></span>
+                    @if(! isset($noSeparator))
+                        <span class="{{ $separatorClasses ?? 'hidden pr-2 border-l ml-7 h-7 border-theme-secondary-300 dark:border-theme-secondary-800 ' . $separatorBreakpointClass }}"></span>
+                    @endif
 
                     <div class="flex inset-y-0 right-0 items-center">
                         @if(is_array($navigation))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/10ht8vj

Property to hide the separator between navigation links and the "content" after it

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
