### PR TITLE
refactor: add focus trap to modal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ window.initClipboard = () => {
 
 ### Modals
 
-1. Install `body-scroll-lock`
+1. Install `body-scroll-lock` and `focus-trap`
 
 ```bash
 yarn add body-scroll-lock
+yarn add focus-trap
 ```
 
 2. Import the modal script in your `resources/js/app.js` file

--- a/resources/assets/js/modal.js
+++ b/resources/assets/js/modal.js
@@ -4,9 +4,12 @@ import {
     clearAllBodyScrollLocks,
 } from "body-scroll-lock";
 
+import { createFocusTrap } from 'focus-trap';
+
 const Modal = {
     previousPaddingRight: undefined,
     previousNavPaddingRight: undefined,
+    trappedElement: null,
 
     defaultSettings: {
         reserveScrollBarGap: true,
@@ -26,7 +29,7 @@ const Modal = {
             reserveScrollBarGap: !!settings.reserveScrollBarGap,
         });
 
-        scrollable.focus();
+        this.trapFocus(scrollable);
     },
 
     onModalClosed(scrollable, settings = Modal.defaultSettings) {
@@ -40,9 +43,30 @@ const Modal = {
 
         enableBodyScroll(scrollable);
 
+        this.releaseTrappedFocus();
+
         if (!document.querySelectorAll("[data-modal]").length) {
             clearAllBodyScrollLocks();
         }
+    },
+
+    trapFocus(el) {
+        let trap = createFocusTrap(el, {
+            escapeDeactivates: false,
+            allowOutsideClick: true
+        })
+
+        this.trappedElement = trap.activate();
+    },
+
+    releaseTrappedFocus() {
+        let trap = this.trappedElement;
+
+        if (trap) {
+            trap.deactivate();
+        }
+
+        this.trappedElement = null;
     },
 
     alpine(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1je5e0d

When a modal is opened, the first focusable element should receive the focus. Tabbing should focus the next sibling and should keep the focus on elements in the modal.
When a modal is closed, the focus should come back to the element used to trigger the modal.
Saying that, this PR improves to modal component to take care of those behaviors.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
