### PR TITLE
refactor: footer copyright spacing tweak

### DIFF
--- a/resources/views/footer-copyright.blade.php
+++ b/resources/views/footer-copyright.blade.php
@@ -9,21 +9,23 @@
         {{ date('Y') }} &copy; {{ $copyText }}
     </span>
 
-    <div class="flex">
-        @if($isArkProduct)
-            <div>
-                <span class="hidden mr-1 sm:inline"> | </span>
-                <span class="whitespace-nowrap">
-                    <x-ark-icon
-                        name="ark-logo-red-square"
-                        class="inline-block mr-1 -mt-1"
-                    />
+    @if($isArkProduct || $copyrightSlot !== null)
+        <div class="flex">
+            @if($isArkProduct)
+                <div>
+                    <span class="hidden mr-1 sm:inline"> | </span>
+                    <span class="whitespace-nowrap">
+                        <x-ark-icon
+                            name="ark-logo-red-square"
+                            class="inline-block mr-1 -mt-1"
+                        />
 
-                    An <a href="https://ark.io/" class="underline hover:no-underline focus-visible:rounded">ARK.io</a> Product
-                </span>
-            </div>
-        @endif
+                        An <a href="https://ark.io/" class="underline hover:no-underline focus-visible:rounded">ARK.io</a> Product
+                    </span>
+                </div>
+            @endif
 
-        {{ $copyrightSlot }}
-    </div>
+            {{ $copyrightSlot }}
+        </div>
+    @endif
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

If there was no copyright slot and the ark product text wasn't being shown, an empty flex container was being output which caused additional padding

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
