### PR TITLE
refactor: tweak local time component tooltip

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -47,6 +47,8 @@ const destroyTippy = (parentEl = document.body) => {
 
 initTippy();
 
+window.tooltipSettings = tooltipSettings;
+
 window.initTippy = initTippy;
 
 window.destroyTippy = destroyTippy;

--- a/resources/views/local-time.blade.php
+++ b/resources/views/local-time.blade.php
@@ -16,6 +16,7 @@
         output = datetime.format(format);
         @if($tooltipFormat)
             tooltip = datetime.format('{{ $tooltipFormat }}');
+            $nextTick(() => tippy($el, tooltipSettings));
         @endif
     "
     x-text="output"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Tooltips for the local time were only being shown after the second livewire load due to `initTippy` being called prior to alpine updating the tooltip content. This now handles initiating tippy on init

Relates to https://github.com/ArkEcosystem/explorer/pull/930

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
